### PR TITLE
Update SBOMs for proton-bridge

### DIFF
--- a/proton-bridge/proton-bridge-v1.6.3.bom.json
+++ b/proton-bridge/proton-bridge-v1.6.3.bom.json
@@ -1,31 +1,31 @@
 {
   "bomFormat": "CycloneDX",
   "specVersion": "1.2",
-  "serialNumber": "urn:uuid:58f3c80e-e102-4dd0-af2c-fd8756d48f52",
+  "serialNumber": "urn:uuid:2392d49c-ea93-44e0-aa36-5923fcfb5efb",
   "version": 1,
   "metadata": {
-    "timestamp": "2021-05-16T15:45:41+02:00",
+    "timestamp": "2021-05-16T17:08:44+02:00",
     "tools": [
       {
         "vendor": "CycloneDX",
         "name": "cyclonedx-gomod",
-        "version": "v0.6.0",
+        "version": "v0.6.1",
         "hashes": [
           {
             "alg": "MD5",
-            "content": "d0517cb759962ccf9c41c8a12875a8f4"
+            "content": "a92d9f6145a94c2c7ad8489d84301eb9"
           },
           {
             "alg": "SHA-1",
-            "content": "0a7059c2ba93d66a6f3b895ea446a74ab8cf24d0"
+            "content": "a5af6c5ef3f21bf5425c680b64acf57cc6a90c69"
           },
           {
             "alg": "SHA-256",
-            "content": "d9695be77c111ebff786b384581b76ccbf4e8e4463969f6e6e22e9dd9a7ed465"
+            "content": "dc215a651772356eca763d6fe77169379c1cc25c2bb89c7d6df2e2170c3972ab"
           },
           {
             "alg": "SHA-512",
-            "content": "9e6f27516614980c9a745574dcf755679efaacf5cf2beafaf1a5ad67ff99f568f811bbac65e9641f3f82c9da8066d28e5487f52f6b1fa179ec9a878e8a7d461d"
+            "content": "387953ab509c31bf352693de9df617650c87494e607119bc284b91ba9a0a2d284a2e96946c272dc284c4370875412eea855bc30351faedd099dbdbed209e4636"
           }
         ]
       }
@@ -61,7 +61,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -90,14 +89,12 @@
         {
           "license": {
             "id": "CC0-1.0",
-            "name": "Creative Commons Zero v1.0 Universal",
             "url": "https://spdx.org/licenses/CC0-1.0.html"
           }
         },
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -126,7 +123,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -155,8 +151,12 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        },
+        {
+          "license": {
+            "name": "GooglePatentClause"
           }
         }
       ],
@@ -184,7 +184,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -213,7 +212,6 @@
         {
           "license": {
             "id": "Apache-2.0",
-            "name": "Apache License 2.0",
             "url": "https://spdx.org/licenses/Apache-2.0.html"
           }
         }
@@ -242,7 +240,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -271,7 +268,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -300,7 +296,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -329,7 +324,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -358,7 +352,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -387,7 +380,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -416,7 +408,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -445,7 +436,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -474,7 +464,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -503,7 +492,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -532,7 +520,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -561,7 +548,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -590,7 +576,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -619,7 +604,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -648,7 +632,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -677,7 +660,6 @@
         {
           "license": {
             "id": "BSD-2-Clause",
-            "name": "BSD 2-Clause \"Simplified\" License",
             "url": "https://spdx.org/licenses/BSD-2-Clause.html"
           }
         }
@@ -706,14 +688,12 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         },
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -742,7 +722,6 @@
         {
           "license": {
             "id": "MPL-2.0",
-            "name": "Mozilla Public License 2.0",
             "url": "https://spdx.org/licenses/MPL-2.0.html"
           }
         }
@@ -771,7 +750,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -820,7 +798,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -849,7 +826,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -878,7 +854,6 @@
         {
           "license": {
             "id": "Apache-2.0",
-            "name": "Apache License 2.0",
             "url": "https://spdx.org/licenses/Apache-2.0.html"
           }
         }
@@ -907,7 +882,6 @@
         {
           "license": {
             "id": "Apache-2.0",
-            "name": "Apache License 2.0",
             "url": "https://spdx.org/licenses/Apache-2.0.html"
           }
         }
@@ -936,7 +910,6 @@
         {
           "license": {
             "id": "Apache-2.0",
-            "name": "Apache License 2.0",
             "url": "https://spdx.org/licenses/Apache-2.0.html"
           }
         }
@@ -965,7 +938,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -994,7 +966,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -1023,7 +994,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -1052,7 +1022,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -1081,7 +1050,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -1110,7 +1078,6 @@
         {
           "license": {
             "id": "ISC",
-            "name": "ISC License",
             "url": "https://spdx.org/licenses/ISC.html"
           }
         }
@@ -1139,7 +1106,6 @@
         {
           "license": {
             "id": "Apache-2.0",
-            "name": "Apache License 2.0",
             "url": "https://spdx.org/licenses/Apache-2.0.html"
           }
         }
@@ -1188,7 +1154,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -1237,7 +1202,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -1266,7 +1230,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -1315,7 +1278,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -1344,7 +1306,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -1373,7 +1334,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -1402,7 +1362,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -1431,7 +1390,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -1460,7 +1418,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -1489,7 +1446,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -1518,7 +1474,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -1547,7 +1502,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -1576,7 +1530,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -1605,7 +1558,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -1634,7 +1586,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -1683,7 +1634,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -1712,7 +1662,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -1741,7 +1690,6 @@
         {
           "license": {
             "id": "Apache-2.0",
-            "name": "Apache License 2.0",
             "url": "https://spdx.org/licenses/Apache-2.0.html"
           }
         }
@@ -1770,7 +1718,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -1799,7 +1746,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -1828,7 +1774,6 @@
         {
           "license": {
             "id": "BSD-2-Clause",
-            "name": "BSD 2-Clause \"Simplified\" License",
             "url": "https://spdx.org/licenses/BSD-2-Clause.html"
           }
         }
@@ -1857,7 +1802,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -1886,7 +1830,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -1915,7 +1858,6 @@
         {
           "license": {
             "id": "BSD-2-Clause",
-            "name": "BSD 2-Clause \"Simplified\" License",
             "url": "https://spdx.org/licenses/BSD-2-Clause.html"
           }
         }
@@ -1944,7 +1886,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -1973,7 +1914,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -2002,7 +1942,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -2031,7 +1970,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -2060,7 +1998,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -2089,7 +2026,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -2118,7 +2054,6 @@
         {
           "license": {
             "id": "Apache-2.0",
-            "name": "Apache License 2.0",
             "url": "https://spdx.org/licenses/Apache-2.0.html"
           }
         }
@@ -2147,7 +2082,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -2176,7 +2110,6 @@
         {
           "license": {
             "id": "Apache-2.0",
-            "name": "Apache License 2.0",
             "url": "https://spdx.org/licenses/Apache-2.0.html"
           }
         }
@@ -2205,7 +2138,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -2234,7 +2166,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -2263,7 +2194,6 @@
         {
           "license": {
             "id": "Apache-2.0",
-            "name": "Apache License 2.0",
             "url": "https://spdx.org/licenses/Apache-2.0.html"
           }
         }
@@ -2292,7 +2222,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -2321,7 +2250,6 @@
         {
           "license": {
             "id": "BSD-2-Clause",
-            "name": "BSD 2-Clause \"Simplified\" License",
             "url": "https://spdx.org/licenses/BSD-2-Clause.html"
           }
         }
@@ -2350,7 +2278,6 @@
         {
           "license": {
             "id": "BSD-2-Clause",
-            "name": "BSD 2-Clause \"Simplified\" License",
             "url": "https://spdx.org/licenses/BSD-2-Clause.html"
           }
         }
@@ -2379,7 +2306,6 @@
         {
           "license": {
             "id": "MPL-2.0",
-            "name": "Mozilla Public License 2.0",
             "url": "https://spdx.org/licenses/MPL-2.0.html"
           }
         }
@@ -2408,7 +2334,6 @@
         {
           "license": {
             "id": "MPL-2.0",
-            "name": "Mozilla Public License 2.0",
             "url": "https://spdx.org/licenses/MPL-2.0.html"
           }
         }
@@ -2437,7 +2362,6 @@
         {
           "license": {
             "id": "MPL-2.0",
-            "name": "Mozilla Public License 2.0",
             "url": "https://spdx.org/licenses/MPL-2.0.html"
           }
         }
@@ -2466,7 +2390,6 @@
         {
           "license": {
             "id": "MPL-2.0",
-            "name": "Mozilla Public License 2.0",
             "url": "https://spdx.org/licenses/MPL-2.0.html"
           }
         }
@@ -2495,7 +2418,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -2524,7 +2446,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -2553,7 +2474,6 @@
         {
           "license": {
             "id": "Apache-2.0",
-            "name": "Apache License 2.0",
             "url": "https://spdx.org/licenses/Apache-2.0.html"
           }
         }
@@ -2582,7 +2502,6 @@
         {
           "license": {
             "id": "BSD-2-Clause",
-            "name": "BSD 2-Clause \"Simplified\" License",
             "url": "https://spdx.org/licenses/BSD-2-Clause.html"
           }
         }
@@ -2611,7 +2530,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -2640,7 +2558,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -2669,7 +2586,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -2718,7 +2634,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -2747,7 +2662,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -2776,7 +2690,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -2805,7 +2718,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -2834,7 +2746,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -2863,7 +2774,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -2892,7 +2802,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -2921,7 +2830,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -2950,7 +2858,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -2979,7 +2886,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -3008,7 +2914,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -3037,7 +2942,6 @@
         {
           "license": {
             "id": "BSD-2-Clause",
-            "name": "BSD 2-Clause \"Simplified\" License",
             "url": "https://spdx.org/licenses/BSD-2-Clause.html"
           }
         }
@@ -3066,7 +2970,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -3095,7 +2998,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -3124,7 +3026,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -3153,7 +3054,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -3182,7 +3082,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -3211,7 +3110,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -3240,7 +3138,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -3269,7 +3166,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -3298,7 +3194,6 @@
         {
           "license": {
             "id": "Unlicense",
-            "name": "The Unlicense",
             "url": "https://spdx.org/licenses/Unlicense.html"
           }
         }
@@ -3327,7 +3222,6 @@
         {
           "license": {
             "id": "BSD-2-Clause",
-            "name": "BSD 2-Clause \"Simplified\" License",
             "url": "https://spdx.org/licenses/BSD-2-Clause.html"
           }
         }
@@ -3356,7 +3250,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -3385,7 +3278,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -3414,7 +3306,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -3443,7 +3334,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -3492,7 +3382,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -3521,7 +3410,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -3550,7 +3438,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -3579,7 +3466,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -3608,7 +3494,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -3637,7 +3522,6 @@
         {
           "license": {
             "id": "Apache-2.0",
-            "name": "Apache License 2.0",
             "url": "https://spdx.org/licenses/Apache-2.0.html"
           }
         }
@@ -3666,7 +3550,6 @@
         {
           "license": {
             "id": "Apache-2.0",
-            "name": "Apache License 2.0",
             "url": "https://spdx.org/licenses/Apache-2.0.html"
           }
         }
@@ -3695,7 +3578,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -3724,7 +3606,6 @@
         {
           "license": {
             "id": "Apache-2.0",
-            "name": "Apache License 2.0",
             "url": "https://spdx.org/licenses/Apache-2.0.html"
           }
         }
@@ -3753,7 +3634,6 @@
         {
           "license": {
             "id": "Apache-2.0",
-            "name": "Apache License 2.0",
             "url": "https://spdx.org/licenses/Apache-2.0.html"
           }
         }
@@ -3782,7 +3662,6 @@
         {
           "license": {
             "id": "Apache-2.0",
-            "name": "Apache License 2.0",
             "url": "https://spdx.org/licenses/Apache-2.0.html"
           }
         }
@@ -3811,7 +3690,6 @@
         {
           "license": {
             "id": "Apache-2.0",
-            "name": "Apache License 2.0",
             "url": "https://spdx.org/licenses/Apache-2.0.html"
           }
         }
@@ -3840,7 +3718,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -3869,7 +3746,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -3898,7 +3774,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -3927,7 +3802,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -3956,7 +3830,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -3985,7 +3858,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -4014,7 +3886,6 @@
         {
           "license": {
             "id": "BSD-2-Clause",
-            "name": "BSD 2-Clause \"Simplified\" License",
             "url": "https://spdx.org/licenses/BSD-2-Clause.html"
           }
         }
@@ -4043,7 +3914,6 @@
         {
           "license": {
             "id": "BSD-2-Clause",
-            "name": "BSD 2-Clause \"Simplified\" License",
             "url": "https://spdx.org/licenses/BSD-2-Clause.html"
           }
         }
@@ -4072,7 +3942,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -4101,7 +3970,6 @@
         {
           "license": {
             "id": "BSD-2-Clause",
-            "name": "BSD 2-Clause \"Simplified\" License",
             "url": "https://spdx.org/licenses/BSD-2-Clause.html"
           }
         }
@@ -4130,7 +3998,6 @@
         {
           "license": {
             "id": "BSD-2-Clause",
-            "name": "BSD 2-Clause \"Simplified\" License",
             "url": "https://spdx.org/licenses/BSD-2-Clause.html"
           }
         }
@@ -4159,7 +4026,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -4188,7 +4054,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -4217,7 +4082,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -4246,7 +4110,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -4275,7 +4138,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -4304,7 +4166,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -4333,7 +4194,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -4362,7 +4222,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -4391,7 +4250,6 @@
         {
           "license": {
             "id": "Apache-2.0",
-            "name": "Apache License 2.0",
             "url": "https://spdx.org/licenses/Apache-2.0.html"
           }
         }
@@ -4420,7 +4278,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -4449,7 +4306,6 @@
         {
           "license": {
             "id": "Apache-2.0",
-            "name": "Apache License 2.0",
             "url": "https://spdx.org/licenses/Apache-2.0.html"
           }
         }
@@ -4478,7 +4334,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -4507,7 +4362,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -4536,7 +4390,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -4565,7 +4418,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -4594,7 +4446,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -4623,7 +4474,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -4652,7 +4502,6 @@
         {
           "license": {
             "id": "LGPL-3.0",
-            "name": "GNU Lesser General Public License v3.0 only",
             "url": "https://spdx.org/licenses/LGPL-3.0.html"
           }
         }
@@ -4681,7 +4530,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -4710,7 +4558,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -4739,7 +4586,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -4768,7 +4614,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -4797,7 +4642,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -4826,7 +4670,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -4855,7 +4698,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -4884,7 +4726,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -4913,7 +4754,6 @@
         {
           "license": {
             "id": "BSD-2-Clause",
-            "name": "BSD 2-Clause \"Simplified\" License",
             "url": "https://spdx.org/licenses/BSD-2-Clause.html"
           }
         }
@@ -4942,7 +4782,6 @@
         {
           "license": {
             "id": "BSD-2-Clause",
-            "name": "BSD 2-Clause \"Simplified\" License",
             "url": "https://spdx.org/licenses/BSD-2-Clause.html"
           }
         }
@@ -4971,7 +4810,6 @@
         {
           "license": {
             "id": "Apache-2.0",
-            "name": "Apache License 2.0",
             "url": "https://spdx.org/licenses/Apache-2.0.html"
           }
         }
@@ -5000,7 +4838,6 @@
         {
           "license": {
             "id": "Apache-2.0",
-            "name": "Apache License 2.0",
             "url": "https://spdx.org/licenses/Apache-2.0.html"
           }
         }
@@ -5029,7 +4866,6 @@
         {
           "license": {
             "id": "Apache-2.0",
-            "name": "Apache License 2.0",
             "url": "https://spdx.org/licenses/Apache-2.0.html"
           }
         }
@@ -5058,7 +4894,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -5087,7 +4922,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -5116,7 +4950,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -5145,7 +4978,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -5194,7 +5026,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -5217,7 +5048,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -5246,7 +5076,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -5269,7 +5098,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -5292,7 +5120,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -5315,7 +5142,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -5338,7 +5164,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -5361,7 +5186,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -5384,7 +5208,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -5407,7 +5230,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -5430,7 +5252,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -5453,7 +5274,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -5476,7 +5296,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -5499,7 +5318,6 @@
         {
           "license": {
             "id": "BSD-2-Clause",
-            "name": "BSD 2-Clause \"Simplified\" License",
             "url": "https://spdx.org/licenses/BSD-2-Clause.html"
           }
         }
@@ -5528,7 +5346,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -5557,7 +5374,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -5586,7 +5402,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -5615,7 +5430,6 @@
         {
           "license": {
             "id": "Apache-2.0",
-            "name": "Apache License 2.0",
             "url": "https://spdx.org/licenses/Apache-2.0.html"
           }
         }
@@ -5644,7 +5458,6 @@
         {
           "license": {
             "id": "BSD-2-Clause",
-            "name": "BSD 2-Clause \"Simplified\" License",
             "url": "https://spdx.org/licenses/BSD-2-Clause.html"
           }
         }
@@ -5673,7 +5486,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -5702,7 +5514,6 @@
         {
           "license": {
             "id": "Apache-2.0",
-            "name": "Apache License 2.0",
             "url": "https://spdx.org/licenses/Apache-2.0.html"
           }
         }
@@ -5731,14 +5542,12 @@
         {
           "license": {
             "id": "Apache-2.0",
-            "name": "Apache License 2.0",
             "url": "https://spdx.org/licenses/Apache-2.0.html"
           }
         },
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }

--- a/proton-bridge/proton-bridge-v1.6.3.bom.json
+++ b/proton-bridge/proton-bridge-v1.6.3.bom.json
@@ -1,0 +1,6695 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.2",
+  "serialNumber": "urn:uuid:58f3c80e-e102-4dd0-af2c-fd8756d48f52",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2021-05-16T15:45:41+02:00",
+    "tools": [
+      {
+        "vendor": "CycloneDX",
+        "name": "cyclonedx-gomod",
+        "version": "v0.6.0",
+        "hashes": [
+          {
+            "alg": "MD5",
+            "content": "d0517cb759962ccf9c41c8a12875a8f4"
+          },
+          {
+            "alg": "SHA-1",
+            "content": "0a7059c2ba93d66a6f3b895ea446a74ab8cf24d0"
+          },
+          {
+            "alg": "SHA-256",
+            "content": "d9695be77c111ebff786b384581b76ccbf4e8e4463969f6e6e22e9dd9a7ed465"
+          },
+          {
+            "alg": "SHA-512",
+            "content": "9e6f27516614980c9a745574dcf755679efaacf5cf2beafaf1a5ad67ff99f568f811bbac65e9641f3f82c9da8066d28e5487f52f6b1fa179ec9a878e8a7d461d"
+          }
+        ]
+      }
+    ],
+    "component": {
+      "bom-ref": "pkg:golang/github.com/ProtonMail/proton-bridge@v1.6.3",
+      "type": "application",
+      "name": "github.com/ProtonMail/proton-bridge",
+      "version": "v1.6.3",
+      "purl": "pkg:golang/github.com/ProtonMail/proton-bridge@v1.6.3",
+      "externalReferences": [
+        {
+          "url": "https://github.com/ProtonMail/proton-bridge",
+          "type": "vcs"
+        }
+      ]
+    }
+  },
+  "components": [
+    {
+      "bom-ref": "pkg:golang/github.com/0xAX/notificator@v0.0.0-20191016112426-3962a5ea8da1",
+      "type": "library",
+      "name": "github.com/0xAX/notificator",
+      "version": "v0.0.0-20191016112426-3962a5ea8da1",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "8fd1da69f6a90db3db1910e4bba7bf1d1b3a28131c287896726d7ff526f19e5e"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/0xAX/notificator@v0.0.0-20191016112426-3962a5ea8da1",
+      "externalReferences": [
+        {
+          "url": "https://github.com/0xAX/notificator",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/AndreasBriese/bbloom@v0.0.0-20190306092124-e2d15f34fcf9",
+      "type": "library",
+      "name": "github.com/AndreasBriese/bbloom",
+      "version": "v0.0.0-20190306092124-e2d15f34fcf9",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "1c3f20036b6407284c03061a1405fdc3697bbf1bc143934ca310eb921aa1b67e"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "CC0-1.0",
+            "name": "Creative Commons Zero v1.0 Universal",
+            "url": "https://spdx.org/licenses/CC0-1.0.html"
+          }
+        },
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/AndreasBriese/bbloom@v0.0.0-20190306092124-e2d15f34fcf9",
+      "externalReferences": [
+        {
+          "url": "https://github.com/AndreasBriese/bbloom",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/BurntSushi/toml@v0.3.1",
+      "type": "library",
+      "name": "github.com/BurntSushi/toml",
+      "version": "v0.3.1",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "597918625e98af7a817f52bbf440672f899a9343a29817c1d1751ff55976f0e4"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/BurntSushi/toml@v0.3.1",
+      "externalReferences": [
+        {
+          "url": "https://github.com/BurntSushi/toml",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/BurntSushi/xgb@v0.0.0-20160522181843-27f122750802",
+      "type": "library",
+      "name": "github.com/BurntSushi/xgb",
+      "version": "v0.0.0-20160522181843-27f122750802",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d410d3cf4bbd9c2dfffe938231d347f828972556098795103423811bb8db10b7"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/BurntSushi/xgb@v0.0.0-20160522181843-27f122750802",
+      "externalReferences": [
+        {
+          "url": "https://github.com/BurntSushi/xgb",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/CloudyKit/fastprinter@v0.0.0-20200109182630-33d98a066a53",
+      "type": "library",
+      "name": "github.com/CloudyKit/fastprinter",
+      "version": "v0.0.0-20200109182630-33d98a066a53",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b11fbff186f8b25b6d078bc3f9bf5bb551275a02f7434d0e053cd54fc07d0b47"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/CloudyKit/fastprinter@v0.0.0-20200109182630-33d98a066a53",
+      "externalReferences": [
+        {
+          "url": "https://github.com/CloudyKit/fastprinter",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/CloudyKit/jet/v3@v3.0.0",
+      "type": "library",
+      "name": "github.com/CloudyKit/jet/v3",
+      "version": "v3.0.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d4fc0ee70e550ad954525f8a4ce06c4c66658635a47326ec19a01abb9dad3b2f"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "name": "Apache License 2.0",
+            "url": "https://spdx.org/licenses/Apache-2.0.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/CloudyKit/jet/v3@v3.0.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/CloudyKit/jet/v3",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/Joker/hpp@v1.0.0",
+      "type": "library",
+      "name": "github.com/Joker/hpp",
+      "version": "v1.0.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "eb9fa2b8961d457bff5f237ad82d6e12698ec77e37dab346feb2a55fa57b2a47"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/Joker/hpp@v1.0.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/Joker/hpp",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/Masterminds/semver/v3@v3.1.0",
+      "type": "library",
+      "name": "github.com/Masterminds/semver/v3",
+      "version": "v3.1.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "6369540ec14a5514981a88cb275c8bc525dd3263184d896cd2b0afa2a98c5109"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/Masterminds/semver/v3@v3.1.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/Masterminds/semver/v3",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/ProtonMail/go-autostart@v0.0.0-20181114175602-c5272053443a",
+      "type": "library",
+      "name": "github.com/ProtonMail/go-autostart",
+      "version": "v0.0.0-20181114175602-c5272053443a",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "7d72b62ac7e790157d361fbd48acc7721623b84f6cd2f236d091b599bb4401c7"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/ProtonMail/go-autostart@v0.0.0-20181114175602-c5272053443a",
+      "externalReferences": [
+        {
+          "url": "https://github.com/ProtonMail/go-autostart",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/ProtonMail/go-crypto@v0.0.0-20201208171014-cdb7591792e2",
+      "type": "library",
+      "name": "github.com/ProtonMail/go-crypto",
+      "version": "v0.0.0-20201208171014-cdb7591792e2",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a509232442c76b25b9f63a7baf81b90e59a789caf931c7a30dfc2c8dcc08d525"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/ProtonMail/go-crypto@v0.0.0-20201208171014-cdb7591792e2",
+      "externalReferences": [
+        {
+          "url": "https://github.com/ProtonMail/go-crypto",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/ProtonMail/go-imap-id@v0.0.0-20190926060100-f94a56b9ecde",
+      "type": "library",
+      "name": "github.com/ProtonMail/go-imap-id",
+      "version": "v0.0.0-20190926060100-f94a56b9ecde",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e64a10a334c310bca660ec856d0fd54ae6dec40117cc347ca8633998ef0645dc"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/ProtonMail/go-imap-id@v0.0.0-20190926060100-f94a56b9ecde",
+      "externalReferences": [
+        {
+          "url": "https://github.com/ProtonMail/go-imap-id",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/ProtonMail/go-mime@v0.0.0-20190923161245-9b5a4261663a",
+      "type": "library",
+      "name": "github.com/ProtonMail/go-mime",
+      "version": "v0.0.0-20190923161245-9b5a4261663a",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "5ba46b80dfec4f18359acab31456fe1bcd0c166a63330eb5214fac966fb0967e"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/ProtonMail/go-mime@v0.0.0-20190923161245-9b5a4261663a",
+      "externalReferences": [
+        {
+          "url": "https://github.com/ProtonMail/go-mime",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/ProtonMail/go-rfc5322@v0.5.0",
+      "type": "library",
+      "name": "github.com/ProtonMail/go-rfc5322",
+      "version": "v0.5.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "2db2968e07efba66190abf01806c93524dc44c69052c08d0764b9252967909c1"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/ProtonMail/go-rfc5322@v0.5.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/ProtonMail/go-rfc5322",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/ProtonMail/go-vcard@v0.0.0-20180326232728-33aaa0a0c8a5",
+      "type": "library",
+      "name": "github.com/ProtonMail/go-vcard",
+      "version": "v0.0.0-20180326232728-33aaa0a0c8a5",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "5206b50c714de06531b8342bd05ef5b698bc23d1ea3c8959a1d640235951e954"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/ProtonMail/go-vcard@v0.0.0-20180326232728-33aaa0a0c8a5",
+      "externalReferences": [
+        {
+          "url": "https://github.com/ProtonMail/go-vcard",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/ProtonMail/gopenpgp/v2@v2.1.3",
+      "type": "library",
+      "name": "github.com/ProtonMail/gopenpgp/v2",
+      "version": "v2.1.3",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e3e9c50c9f56b5c5104e2a7f8ded8b9773f6d57840525e1ab16b1a7cbaf0f7b7"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/ProtonMail/gopenpgp/v2@v2.1.3",
+      "externalReferences": [
+        {
+          "url": "https://github.com/ProtonMail/gopenpgp/v2",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/PuerkitoBio/goquery@v1.5.1",
+      "type": "library",
+      "name": "github.com/PuerkitoBio/goquery",
+      "version": "v1.5.1",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "3d23c11a77bc348516c3effbbc5055fa41b627fe4c3a36f373bd79e0e68a0921"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/PuerkitoBio/goquery@v1.5.1",
+      "externalReferences": [
+        {
+          "url": "https://github.com/PuerkitoBio/goquery",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/Shopify/goreferrer@v0.0.0-20181106222321-ec9c9a553398",
+      "type": "library",
+      "name": "github.com/Shopify/goreferrer",
+      "version": "v0.0.0-20181106222321-ec9c9a553398",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "5830bac92a49cdbc4658587868cc45142dbcc301a9e6912ea13b6f038abfa90e"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/Shopify/goreferrer@v0.0.0-20181106222321-ec9c9a553398",
+      "externalReferences": [
+        {
+          "url": "https://github.com/Shopify/goreferrer",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/abiosoft/ishell@v2.0.0",
+      "type": "library",
+      "name": "github.com/abiosoft/ishell",
+      "version": "v2.0.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "8d07f1eba8739e5600b70cc656d8505a7d052643c1f03240f3d56c500f47b876"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/abiosoft/ishell@v2.0.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/abiosoft/ishell",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/abiosoft/readline@v0.0.0-20180607040430-155bce2042db",
+      "type": "library",
+      "name": "github.com/abiosoft/readline",
+      "version": "v0.0.0-20180607040430-155bce2042db",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "0a33d44973a2629b4b6d376bd5171eb9981214343b535e484c44541ab50e471f"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/abiosoft/readline@v0.0.0-20180607040430-155bce2042db",
+      "externalReferences": [
+        {
+          "url": "https://github.com/abiosoft/readline",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/ajg/form@v1.5.1",
+      "type": "library",
+      "name": "github.com/ajg/form",
+      "version": "v1.5.1",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b7d73bbfc2542aefd7c4e181534ca336968c968c4610985492a151ab489b19e5"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/ajg/form@v1.5.1",
+      "externalReferences": [
+        {
+          "url": "https://github.com/ajg/form",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/allan-simon/go-singleinstance@v0.0.0-20160830203053-79edcfdc2dfc",
+      "type": "library",
+      "name": "github.com/allan-simon/go-singleinstance",
+      "version": "v0.0.0-20160830203053-79edcfdc2dfc",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "99971ad3f1d9fd75973fdb7191f765d861fa994cc1a80972273deee4b83c7ee0"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/allan-simon/go-singleinstance@v0.0.0-20160830203053-79edcfdc2dfc",
+      "externalReferences": [
+        {
+          "url": "https://github.com/allan-simon/go-singleinstance",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/andybalholm/cascadia@v1.1.0",
+      "type": "library",
+      "name": "github.com/andybalholm/cascadia",
+      "version": "v1.1.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "06eb8eeac49f40d151bb52e9a606c3db91ebdaf2d85b6e49bf11ece73cec2d3a"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-2-Clause",
+            "name": "BSD 2-Clause \"Simplified\" License",
+            "url": "https://spdx.org/licenses/BSD-2-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/andybalholm/cascadia@v1.1.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/andybalholm/cascadia",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/antlr/antlr4@v0.0.0-20201029161626-9a95f0cc3d7c",
+      "type": "library",
+      "name": "github.com/antlr/antlr4",
+      "version": "v0.0.0-20201029161626-9a95f0cc3d7c",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "8ff0b69313dfc84d1df3bfe08008c8b0257909d92a9a36fe3b45bc5bed49f886"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        },
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/antlr/antlr4@v0.0.0-20201029161626-9a95f0cc3d7c",
+      "externalReferences": [
+        {
+          "url": "https://github.com/antlr/antlr4",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/armon/consul-api@v0.0.0-20180202201655-eb2c6b5be1b6",
+      "type": "library",
+      "name": "github.com/armon/consul-api",
+      "version": "v0.0.0-20180202201655-eb2c6b5be1b6",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "1b56cfbdc8b037217b21498a5cdb7d024de6eaef43135ac5f919ad22406955d0"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MPL-2.0",
+            "name": "Mozilla Public License 2.0",
+            "url": "https://spdx.org/licenses/MPL-2.0.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/armon/consul-api@v0.0.0-20180202201655-eb2c6b5be1b6",
+      "externalReferences": [
+        {
+          "url": "https://github.com/armon/consul-api",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/aymerick/raymond@v2.0.3-0.20180322193309-b565731e1464",
+      "type": "library",
+      "name": "github.com/aymerick/raymond",
+      "version": "v2.0.3-0.20180322193309-b565731e1464",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "901a7783930a0426984323b3db44d35643a9cadacc01a92f2fb43fcf530b35cf"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/aymerick/raymond@v2.0.3-0.20180322193309-b565731e1464",
+      "externalReferences": [
+        {
+          "url": "https://github.com/aymerick/raymond",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/chzyer/logex@v1.1.10",
+      "type": "library",
+      "name": "github.com/chzyer/logex",
+      "version": "v1.1.10",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "4b0a5ad4ae90bd0ce7c0945c7d37d02664c4ef60ea49c01ae3413e7db1c45c41"
+        }
+      ],
+      "purl": "pkg:golang/github.com/chzyer/logex@v1.1.10",
+      "externalReferences": [
+        {
+          "url": "https://github.com/chzyer/logex",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/chzyer/test@v0.0.0-20180213035817-a1ea475d72b1",
+      "type": "library",
+      "name": "github.com/chzyer/test",
+      "version": "v0.0.0-20180213035817-a1ea475d72b1",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "abbeb7a9ff61b8dd7590341abd6b2865724d5b7c44138249c876b9436e7fb1df"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/chzyer/test@v0.0.0-20180213035817-a1ea475d72b1",
+      "externalReferences": [
+        {
+          "url": "https://github.com/chzyer/test",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/codegangsta/inject@v0.0.0-20150114235600-33e0aa1cb7c0",
+      "type": "library",
+      "name": "github.com/codegangsta/inject",
+      "version": "v0.0.0-20150114235600-33e0aa1cb7c0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b033269beabfdfe06e91d229c703b7eb9bff45bb29a7636de579ed810457abc4"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/codegangsta/inject@v0.0.0-20150114235600-33e0aa1cb7c0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/codegangsta/inject",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/coreos/etcd@v3.3.10",
+      "type": "library",
+      "name": "github.com/coreos/etcd",
+      "version": "v3.3.10",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a1d778f324614e5305c1bc3b560cea519671ae74a7f543baf8f691436c8a04d6"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "name": "Apache License 2.0",
+            "url": "https://spdx.org/licenses/Apache-2.0.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/coreos/etcd@v3.3.10",
+      "externalReferences": [
+        {
+          "url": "https://github.com/coreos/etcd",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/coreos/go-etcd@v2.0.0",
+      "type": "library",
+      "name": "github.com/coreos/go-etcd",
+      "version": "v2.0.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "59a79e10ff2bd1332fc3a102b612acc787b325fc00354abbba215db513c291c5"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "name": "Apache License 2.0",
+            "url": "https://spdx.org/licenses/Apache-2.0.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/coreos/go-etcd@v2.0.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/coreos/go-etcd",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/coreos/go-semver@v0.2.0",
+      "type": "library",
+      "name": "github.com/coreos/go-semver",
+      "version": "v0.2.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "dc99b7b4b9ac80061c8c2fb8529ee126b1413ebfa7eeb02a61e4b0fd265acee6"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "name": "Apache License 2.0",
+            "url": "https://spdx.org/licenses/Apache-2.0.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/coreos/go-semver@v0.2.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/coreos/go-semver",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/cpuguy83/go-md2man@v1.0.10",
+      "type": "library",
+      "name": "github.com/cpuguy83/go-md2man",
+      "version": "v1.0.10",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "05228c3656310ef9ee9e54f29aab6038d8cd9da455d6c4e9728bf0c23176da39"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/cpuguy83/go-md2man@v1.0.10",
+      "externalReferences": [
+        {
+          "url": "https://github.com/cpuguy83/go-md2man",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/cpuguy83/go-md2man/v2@v2.0.0-20190314233015-f79a8a8ca69d",
+      "type": "library",
+      "name": "github.com/cpuguy83/go-md2man/v2",
+      "version": "v2.0.0-20190314233015-f79a8a8ca69d",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "53eb3dd144d2620a6d64cc10876691af72ee6b32c921af8f83729cd729526156"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/cpuguy83/go-md2man/v2@v2.0.0-20190314233015-f79a8a8ca69d",
+      "externalReferences": [
+        {
+          "url": "https://github.com/cpuguy83/go-md2man/v2",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/creack/pty@v1.1.9",
+      "type": "library",
+      "name": "github.com/creack/pty",
+      "version": "v1.1.9",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b8399a1b371d8e11788bfa65823984b2b887d75634a3b44a6a911ffcb0da337c"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/creack/pty@v1.1.9",
+      "externalReferences": [
+        {
+          "url": "https://github.com/creack/pty",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/cucumber/godog@v0.8.1",
+      "type": "library",
+      "name": "github.com/cucumber/godog",
+      "version": "v0.8.1",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "9556fe5f8d48e180eb784fa26d9e746dd5e6c92c6046f898160298e80c385c4f"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/cucumber/godog@v0.8.1",
+      "externalReferences": [
+        {
+          "url": "https://github.com/cucumber/godog",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/danieljoos/wincred@v1.1.0",
+      "type": "library",
+      "name": "github.com/danieljoos/wincred",
+      "version": "v1.1.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "dd135c129060e088480a165d15149d950b754230a9d6c3003c8ace9e6ed87fc8"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/danieljoos/wincred@v1.1.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/danieljoos/wincred",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+      "type": "library",
+      "name": "github.com/davecgh/go-spew",
+      "version": "v1.1.1",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "be3f63feed5baa7bc211f24ec1486d94e011aacdfeae41d8635de36164d4f7b7"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "ISC",
+            "name": "ISC License",
+            "url": "https://spdx.org/licenses/ISC.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+      "externalReferences": [
+        {
+          "url": "https://github.com/davecgh/go-spew",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/dgraph-io/badger@v1.6.0",
+      "type": "library",
+      "name": "github.com/dgraph-io/badger",
+      "version": "v1.6.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "0ec8711716565d470ed315f8efa5490b4ed7b2be990815511ca67ddce87b12fa"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "name": "Apache License 2.0",
+            "url": "https://spdx.org/licenses/Apache-2.0.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/dgraph-io/badger@v1.6.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/dgraph-io/badger",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/dgrijalva/jwt-go@v3.2.0",
+      "type": "library",
+      "name": "github.com/dgrijalva/jwt-go",
+      "version": "v3.2.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d2b9d7df363078b7430fbcdb250dd4d9ee4e0d47558a64736ba797e38e8829dc"
+        }
+      ],
+      "purl": "pkg:golang/github.com/dgrijalva/jwt-go@v3.2.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/dgrijalva/jwt-go",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/dgryski/go-farm@v0.0.0-20190423205320-6a90982ecee2",
+      "type": "library",
+      "name": "github.com/dgryski/go-farm",
+      "version": "v0.0.0-20190423205320-6a90982ecee2",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b5d9590a967f3fd0e17330934a2c6020a9b03efebec0fe431a3a8b630e525220"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/dgryski/go-farm@v0.0.0-20190423205320-6a90982ecee2",
+      "externalReferences": [
+        {
+          "url": "https://github.com/dgryski/go-farm",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/ProtonMail/docker-credential-helpers@v1.1.0",
+      "type": "library",
+      "name": "github.com/ProtonMail/docker-credential-helpers",
+      "version": "v1.1.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "fa4bd4229c1671bb4fdd616fe6c4af9059ff5cbcd2a8f381e4002d86e93dc4f9"
+        }
+      ],
+      "purl": "pkg:golang/github.com/ProtonMail/docker-credential-helpers@v1.1.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/ProtonMail/docker-credential-helpers",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/dustin/go-humanize@v1.0.0",
+      "type": "library",
+      "name": "github.com/dustin/go-humanize",
+      "version": "v1.0.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "5529d3b180a79451da336fe280ed61e97dc703bd637286d0bb17a6824ab8cd8a"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/dustin/go-humanize@v1.0.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/dustin/go-humanize",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/eknkc/amber@v0.0.0-20171010120322-cdade1c07385",
+      "type": "library",
+      "name": "github.com/eknkc/amber",
+      "version": "v0.0.0-20171010120322-cdade1c07385",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "7250b59570697b69138f654775a22ef5a8d941ee2470463d8f436c9c30c1677a"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/eknkc/amber@v0.0.0-20171010120322-cdade1c07385",
+      "externalReferences": [
+        {
+          "url": "https://github.com/eknkc/amber",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/ProtonMail/go-imap@v0.0.0-20201228133358-4db68cea0cac",
+      "type": "library",
+      "name": "github.com/ProtonMail/go-imap",
+      "version": "v0.0.0-20201228133358-4db68cea0cac",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "db1537427700892fd6dd495665391b34a5b95a42f393a1209754f4c57fac6e3b"
+        }
+      ],
+      "purl": "pkg:golang/github.com/ProtonMail/go-imap@v0.0.0-20201228133358-4db68cea0cac",
+      "externalReferences": [
+        {
+          "url": "https://github.com/ProtonMail/go-imap",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/emersion/go-imap-appendlimit@v0.0.0-20190308131241-25671c986a6a",
+      "type": "library",
+      "name": "github.com/emersion/go-imap-appendlimit",
+      "version": "v0.0.0-20190308131241-25671c986a6a",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "6cc7523e6eacb2cb8e16921abdebb75c60228cc4b74ead92dc4a8566667189d7"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/emersion/go-imap-appendlimit@v0.0.0-20190308131241-25671c986a6a",
+      "externalReferences": [
+        {
+          "url": "https://github.com/emersion/go-imap-appendlimit",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/emersion/go-imap-idle@v0.0.0-20200601154248-f05f54664cc4",
+      "type": "library",
+      "name": "github.com/emersion/go-imap-idle",
+      "version": "v0.0.0-20200601154248-f05f54664cc4",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "fc92002f398276e7f9a3c4d625288e0734dbf7e47448287012552b24b969da9a"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/emersion/go-imap-idle@v0.0.0-20200601154248-f05f54664cc4",
+      "externalReferences": [
+        {
+          "url": "https://github.com/emersion/go-imap-idle",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/emersion/go-imap-move@v0.0.0-20190710073258-6e5a51a5b342",
+      "type": "library",
+      "name": "github.com/emersion/go-imap-move",
+      "version": "v0.0.0-20190710073258-6e5a51a5b342",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e69d6ddded4fa266202d6c04c21c0453991507073201c56b3a97b1bfc01e671d"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/emersion/go-imap-move@v0.0.0-20190710073258-6e5a51a5b342",
+      "externalReferences": [
+        {
+          "url": "https://github.com/emersion/go-imap-move",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/emersion/go-imap-quota@v0.0.0-20200423100218-dcfd1b7d2b41",
+      "type": "library",
+      "name": "github.com/emersion/go-imap-quota",
+      "version": "v0.0.0-20200423100218-dcfd1b7d2b41",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "cf99431a749445ab8110374d2e3de8d3e1e881560a40219e63702797fc7245f5"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/emersion/go-imap-quota@v0.0.0-20200423100218-dcfd1b7d2b41",
+      "externalReferences": [
+        {
+          "url": "https://github.com/emersion/go-imap-quota",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/emersion/go-imap-unselect@v0.0.0-20171113212723-b985794e5f26",
+      "type": "library",
+      "name": "github.com/emersion/go-imap-unselect",
+      "version": "v0.0.0-20171113212723-b985794e5f26",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "16249bf3e5c14104a4717dee6ebfb5b40b6544905868599166a380c1e67d5b2f"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/emersion/go-imap-unselect@v0.0.0-20171113212723-b985794e5f26",
+      "externalReferences": [
+        {
+          "url": "https://github.com/emersion/go-imap-unselect",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/emersion/go-mbox@v1.0.2",
+      "type": "library",
+      "name": "github.com/emersion/go-mbox",
+      "version": "v1.0.2",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b44feb4fe944ba02bdcb49b21329820879f0959374e219573eb6ca9314410392"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/emersion/go-mbox@v1.0.2",
+      "externalReferences": [
+        {
+          "url": "https://github.com/emersion/go-mbox",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/emersion/go-message@v0.12.1-0.20201221184100-40c3f864532b",
+      "type": "library",
+      "name": "github.com/emersion/go-message",
+      "version": "v0.12.1-0.20201221184100-40c3f864532b",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "c58ba15ba7a04da08ffb38db51c7e8cbf0ebdc049d54f47d5bb7e6907bd91cf1"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/emersion/go-message@v0.12.1-0.20201221184100-40c3f864532b",
+      "externalReferences": [
+        {
+          "url": "https://github.com/emersion/go-message",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/emersion/go-sasl@v0.0.0-20200509203442-7bfe0ed36a21",
+      "type": "library",
+      "name": "github.com/emersion/go-sasl",
+      "version": "v0.0.0-20200509203442-7bfe0ed36a21",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "389c9418c253cc74ddd57429f7c4136877ab9f1318cd168e6ac462afd8549454"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/emersion/go-sasl@v0.0.0-20200509203442-7bfe0ed36a21",
+      "externalReferences": [
+        {
+          "url": "https://github.com/emersion/go-sasl",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/emersion/go-smtp@v0.14.0",
+      "type": "library",
+      "name": "github.com/emersion/go-smtp",
+      "version": "v0.14.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "4585b6d37a7e11c3e32fc67f6694fd959ea239cf0c1b5310cc4c7550a1245e50"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/emersion/go-smtp@v0.14.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/emersion/go-smtp",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/emersion/go-textwrapper@v0.0.0-20200911093747-65d896831594",
+      "type": "library",
+      "name": "github.com/emersion/go-textwrapper",
+      "version": "v0.0.0-20200911093747-65d896831594",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "21b141b70a13432c347c8339c6fd4717e63edd98a30d1f37f5632e960c427146"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/emersion/go-textwrapper@v0.0.0-20200911093747-65d896831594",
+      "externalReferences": [
+        {
+          "url": "https://github.com/emersion/go-textwrapper",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/emersion/go-vcard@v0.0.0-20190105225839-8856043f13c5",
+      "type": "library",
+      "name": "github.com/emersion/go-vcard",
+      "version": "v0.0.0-20190105225839-8856043f13c5",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "9fdab1f7cc624b9578c76588a4f0b6aebf6650ce6b8bdaff62108429b8421eba"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/emersion/go-vcard@v0.0.0-20190105225839-8856043f13c5",
+      "externalReferences": [
+        {
+          "url": "https://github.com/emersion/go-vcard",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/etcd-io/bbolt@v1.3.3",
+      "type": "library",
+      "name": "github.com/etcd-io/bbolt",
+      "version": "v1.3.3",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "812266c6bb37ecb813a91fe8c89056a24ea4e92bd71147ab1536e5b488579013"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/etcd-io/bbolt@v1.3.3",
+      "externalReferences": [
+        {
+          "url": "https://github.com/etcd-io/bbolt",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/fasthttp-contrib/websocket@v0.0.0-20160511215533-1f3b11f56072",
+      "type": "library",
+      "name": "github.com/fasthttp-contrib/websocket",
+      "version": "v0.0.0-20160511215533-1f3b11f56072",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "0dd76a01a583a72c32b5c1bcc3faa8439b0037c5f5d9ddd9de4a01d02dd1c6c7"
+        }
+      ],
+      "purl": "pkg:golang/github.com/fasthttp-contrib/websocket@v0.0.0-20160511215533-1f3b11f56072",
+      "externalReferences": [
+        {
+          "url": "https://github.com/fasthttp-contrib/websocket",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/fatih/color@v1.9.0",
+      "type": "library",
+      "name": "github.com/fatih/color",
+      "version": "v1.9.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "f313c7978fead55caa1883e27f517ed55dd8de54a6aead3511a6d45b70a85b9b"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/fatih/color@v1.9.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/fatih/color",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/fatih/structs@v1.1.0",
+      "type": "library",
+      "name": "github.com/fatih/structs",
+      "version": "v1.1.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "43b8ee0ccd10b5c9e10a97b22c640aca0e13388821b8d5eb90bdf6a47014331a"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/fatih/structs@v1.1.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/fatih/structs",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/flynn-archive/go-shlex@v0.0.0-20150515145356-3f9db97f8568",
+      "type": "library",
+      "name": "github.com/flynn-archive/go-shlex",
+      "version": "v0.0.0-20150515145356-3f9db97f8568",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "04c5d86115932ce24a961fa5381b7a9d44205c07c1ee854842de5c36b7aa48b2"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "name": "Apache License 2.0",
+            "url": "https://spdx.org/licenses/Apache-2.0.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/flynn-archive/go-shlex@v0.0.0-20150515145356-3f9db97f8568",
+      "externalReferences": [
+        {
+          "url": "https://github.com/flynn-archive/go-shlex",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7",
+      "type": "library",
+      "name": "github.com/fsnotify/fsnotify",
+      "version": "v1.4.7",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "217b3e40b9a75d6d82717b98fbc333bff7d612c3c65b1a9e7cfb423f90a757d2"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7",
+      "externalReferences": [
+        {
+          "url": "https://github.com/fsnotify/fsnotify",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/gavv/httpexpect@v2.0.0",
+      "type": "library",
+      "name": "github.com/gavv/httpexpect",
+      "version": "v2.0.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d5a4f508239e746148054abbe0bc6698ac1c20fe4b3a3573988749e29b213db8"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/gavv/httpexpect@v2.0.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/gavv/httpexpect",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/getsentry/sentry-go@v0.8.0",
+      "type": "library",
+      "name": "github.com/getsentry/sentry-go",
+      "version": "v0.8.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "179d9c8c154bba24df756ea9e0916ec65b77a4e8ca7d6613fda91aedc749eefd"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-2-Clause",
+            "name": "BSD 2-Clause \"Simplified\" License",
+            "url": "https://spdx.org/licenses/BSD-2-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/getsentry/sentry-go@v0.8.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/getsentry/sentry-go",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/gin-contrib/sse@v0.0.0-20190301062529-5545eab6dad3",
+      "type": "library",
+      "name": "github.com/gin-contrib/sse",
+      "version": "v0.0.0-20190301062529-5545eab6dad3",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b7c155930df72fec2295fd90896930d1457beea469707fc91cf286a4a6b613c8"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/gin-contrib/sse@v0.0.0-20190301062529-5545eab6dad3",
+      "externalReferences": [
+        {
+          "url": "https://github.com/gin-contrib/sse",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/gin-gonic/gin@v1.4.0",
+      "type": "library",
+      "name": "github.com/gin-gonic/gin",
+      "version": "v1.4.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ded3280827ccee9a6ab11d29b73ff08b58a6a4da53efff7042d319f25af59824"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/gin-gonic/gin@v1.4.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/gin-gonic/gin",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/go-check/check@v0.0.0-20180628173108-788fd7840127",
+      "type": "library",
+      "name": "github.com/go-check/check",
+      "version": "v0.0.0-20180628173108-788fd7840127",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d2090fea6cda32a926a5c25808538b90807023bc451311b4ddb6e43a40af50f2"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-2-Clause",
+            "name": "BSD 2-Clause \"Simplified\" License",
+            "url": "https://spdx.org/licenses/BSD-2-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/go-check/check@v0.0.0-20180628173108-788fd7840127",
+      "externalReferences": [
+        {
+          "url": "https://github.com/go-check/check",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/go-errors/errors@v1.0.1",
+      "type": "library",
+      "name": "github.com/go-errors/errors",
+      "version": "v1.0.1",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "2d41f39a42b7194294acbff581f054c401f371ebf76a94257b35fff8eee66bac"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/go-errors/errors@v1.0.1",
+      "externalReferences": [
+        {
+          "url": "https://github.com/go-errors/errors",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/go-martini/martini@v0.0.0-20170121215854-22fa46961aab",
+      "type": "library",
+      "name": "github.com/go-martini/martini",
+      "version": "v0.0.0-20170121215854-22fa46961aab",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "c6f78a5b3da26ae79e4da52075eb737a5f94edec728a00d806bcb255f57fad99"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/go-martini/martini@v0.0.0-20170121215854-22fa46961aab",
+      "externalReferences": [
+        {
+          "url": "https://github.com/go-martini/martini",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/go-resty/resty/v2@v2.3.0",
+      "type": "library",
+      "name": "github.com/go-resty/resty/v2",
+      "version": "v2.3.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "24e39e02f8d295aa534fdda9f31892d7d6717afd677868a4a07b1725e3aaf12a"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/go-resty/resty/v2@v2.3.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/go-resty/resty/v2",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/gobwas/httphead@v0.0.0-20180130184737-2c6c146eadee",
+      "type": "library",
+      "name": "github.com/gobwas/httphead",
+      "version": "v0.0.0-20180130184737-2c6c146eadee",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b3edb528daa5a5e3df91a87623e8301c5f319895918e8a18fb9db8f24ea6e00d"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/gobwas/httphead@v0.0.0-20180130184737-2c6c146eadee",
+      "externalReferences": [
+        {
+          "url": "https://github.com/gobwas/httphead",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/gobwas/pool@v0.2.0",
+      "type": "library",
+      "name": "github.com/gobwas/pool",
+      "version": "v0.2.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "4049943a59d28d6b67a5118717749ab8488eb32f360aea7cdd57f62dc3259dcf"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/gobwas/pool@v0.2.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/gobwas/pool",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/gobwas/ws@v1.0.2",
+      "type": "library",
+      "name": "github.com/gobwas/ws",
+      "version": "v1.0.2",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "0a801abd6ff077f92e95f66648806dea9db89f88fbb4780d5428ec7c754d51ba"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/gobwas/ws@v1.0.2",
+      "externalReferences": [
+        {
+          "url": "https://github.com/gobwas/ws",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/golang/mock@v1.4.4",
+      "type": "library",
+      "name": "github.com/golang/mock",
+      "version": "v1.4.4",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "97be425c6452c1b69836997f6765f55c82003120aabaf5e0a5564387010826c7"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "name": "Apache License 2.0",
+            "url": "https://spdx.org/licenses/Apache-2.0.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/golang/mock@v1.4.4",
+      "externalReferences": [
+        {
+          "url": "https://github.com/golang/mock",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/golang/protobuf@v1.3.1",
+      "type": "library",
+      "name": "github.com/golang/protobuf",
+      "version": "v1.3.1",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "605f3e7e50574b978ef36e93e27cea3ebc5f8504e18579746337ee50fbb84818"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/golang/protobuf@v1.3.1",
+      "externalReferences": [
+        {
+          "url": "https://github.com/golang/protobuf",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/gomodule/redigo@v1.7.1-0.20190724094224-574c33c3df38",
+      "type": "library",
+      "name": "github.com/gomodule/redigo",
+      "version": "v1.7.1-0.20190724094224-574c33c3df38",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "cb45a686f9a5edc1a7ccf6bd9e8727fdf32b68c1ff94c0dd786fab931e158186"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "name": "Apache License 2.0",
+            "url": "https://spdx.org/licenses/Apache-2.0.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/gomodule/redigo@v1.7.1-0.20190724094224-574c33c3df38",
+      "externalReferences": [
+        {
+          "url": "https://github.com/gomodule/redigo",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/google/go-cmp@v0.5.1",
+      "type": "library",
+      "name": "github.com/google/go-cmp",
+      "version": "v0.5.1",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "245ac51016f6c4ab9f83a5e426c26bf966ca6f8150954462e5151c06f798bbd9"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/google/go-cmp@v0.5.1",
+      "externalReferences": [
+        {
+          "url": "https://github.com/google/go-cmp",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/google/go-querystring@v1.0.0",
+      "type": "library",
+      "name": "github.com/google/go-querystring",
+      "version": "v1.0.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "5e4c22fdad6b72f360d4f3d87b9bc8f066de058fe3ad5b835f9012b803564eb9"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/google/go-querystring@v1.0.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/google/go-querystring",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/google/gofuzz@v1.0.0",
+      "type": "library",
+      "name": "github.com/google/gofuzz",
+      "version": "v1.0.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "03c3de5b9f69c44f48a0546a069dfb53e99235a428678e85d5fd1ff3add7497c"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "name": "Apache License 2.0",
+            "url": "https://spdx.org/licenses/Apache-2.0.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/google/gofuzz@v1.0.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/google/gofuzz",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/google/uuid@v1.1.1",
+      "type": "library",
+      "name": "github.com/google/uuid",
+      "version": "v1.1.1",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "1a46dcb21fc66e95f3ee53dfb4b0373fa4d83308c22d89bcde388541917fde06"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/google/uuid@v1.1.1",
+      "externalReferences": [
+        {
+          "url": "https://github.com/google/uuid",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/gopherjs/gopherjs@v0.0.0-20190430165422-3e4dfb77656c",
+      "type": "library",
+      "name": "github.com/gopherjs/gopherjs",
+      "version": "v0.0.0-20190430165422-3e4dfb77656c",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ee517e573d0baa2462767cc2d4eabce9fa57d6afe212fd8a25dac2b6db588d3e"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-2-Clause",
+            "name": "BSD 2-Clause \"Simplified\" License",
+            "url": "https://spdx.org/licenses/BSD-2-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/gopherjs/gopherjs@v0.0.0-20190430165422-3e4dfb77656c",
+      "externalReferences": [
+        {
+          "url": "https://github.com/gopherjs/gopherjs",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/gorilla/websocket@v1.4.1",
+      "type": "library",
+      "name": "github.com/gorilla/websocket",
+      "version": "v1.4.1",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "abb01e0c1a67064f00a20703e0349a83f524c3f295f988732e3d9b3f91ef2823"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-2-Clause",
+            "name": "BSD 2-Clause \"Simplified\" License",
+            "url": "https://spdx.org/licenses/BSD-2-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/gorilla/websocket@v1.4.1",
+      "externalReferences": [
+        {
+          "url": "https://github.com/gorilla/websocket",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/hashicorp/errwrap@v1.0.0",
+      "type": "library",
+      "name": "github.com/hashicorp/errwrap",
+      "version": "v1.0.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "84baeab440e74727b7fac831eb3e2a54b36ebe21f7311e5a434ca43496bf5180"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MPL-2.0",
+            "name": "Mozilla Public License 2.0",
+            "url": "https://spdx.org/licenses/MPL-2.0.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/hashicorp/errwrap@v1.0.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/hashicorp/errwrap",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/hashicorp/go-multierror@v1.1.0",
+      "type": "library",
+      "name": "github.com/hashicorp/go-multierror",
+      "version": "v1.1.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "07d533c064097a19d4635c8dae7c111077377c66c2db179fa3c8384db12569c2"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MPL-2.0",
+            "name": "Mozilla Public License 2.0",
+            "url": "https://spdx.org/licenses/MPL-2.0.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/hashicorp/go-multierror@v1.1.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/hashicorp/go-multierror",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/hashicorp/go-version@v1.2.0",
+      "type": "library",
+      "name": "github.com/hashicorp/go-version",
+      "version": "v1.2.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "def35efdf585e4206044882e75ad6679686c647cb79bc802279c31f9d2335ff1"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MPL-2.0",
+            "name": "Mozilla Public License 2.0",
+            "url": "https://spdx.org/licenses/MPL-2.0.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/hashicorp/go-version@v1.2.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/hashicorp/go-version",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/hashicorp/hcl@v1.0.0",
+      "type": "library",
+      "name": "github.com/hashicorp/hcl",
+      "version": "v1.0.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d009e5ce3a62e2f11ab1378d167da62c98134b0b74fbab1fb224c6f2a7161b1e"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MPL-2.0",
+            "name": "Mozilla Public License 2.0",
+            "url": "https://spdx.org/licenses/MPL-2.0.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/hashicorp/hcl@v1.0.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/hashicorp/hcl",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/hpcloud/tail@v1.0.0",
+      "type": "library",
+      "name": "github.com/hpcloud/tail",
+      "version": "v1.0.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "9df08ebca61f92060ff21922ae12687174f6fb3383f3250d8d76967d397214a2"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/hpcloud/tail@v1.0.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/hpcloud/tail",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/imkira/go-interpol@v1.1.0",
+      "type": "library",
+      "name": "github.com/imkira/go-interpol",
+      "version": "v1.1.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "28888aaf45521b60945b5865d63a62caecee25e2945290bc88cd40204ecdd559"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/imkira/go-interpol@v1.1.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/imkira/go-interpol",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/inconshreveable/mousetrap@v1.0.0",
+      "type": "library",
+      "name": "github.com/inconshreveable/mousetrap",
+      "version": "v1.0.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "67cb6ee6cada2d709721c011c41a7ff1c6ef97055aed9d4d1e0f5710a86d4af3"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "name": "Apache License 2.0",
+            "url": "https://spdx.org/licenses/Apache-2.0.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/inconshreveable/mousetrap@v1.0.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/inconshreveable/mousetrap",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/iris-contrib/blackfriday@v2.0.0",
+      "type": "library",
+      "name": "github.com/iris-contrib/blackfriday",
+      "version": "v2.0.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "c5559ad5703151c00b9cbdf6a4f9ddf9523f0237c1fe0be6e7ba85a99b401409"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-2-Clause",
+            "name": "BSD 2-Clause \"Simplified\" License",
+            "url": "https://spdx.org/licenses/BSD-2-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/iris-contrib/blackfriday@v2.0.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/iris-contrib/blackfriday",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/iris-contrib/go.uuid@v2.0.0",
+      "type": "library",
+      "name": "github.com/iris-contrib/go.uuid",
+      "version": "v2.0.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "9db9571d236874d6904bc950503b1018e05b5e904a360fc8e7e299ed6de635d1"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/iris-contrib/go.uuid@v2.0.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/iris-contrib/go.uuid",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/iris-contrib/jade@v1.1.3",
+      "type": "library",
+      "name": "github.com/iris-contrib/jade",
+      "version": "v1.1.3",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a7b27fe74234723a34c2afd559508315df2d68f25bb850be6eadb74a7891157d"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/iris-contrib/jade@v1.1.3",
+      "externalReferences": [
+        {
+          "url": "https://github.com/iris-contrib/jade",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/iris-contrib/pongo2@v0.0.1",
+      "type": "library",
+      "name": "github.com/iris-contrib/pongo2",
+      "version": "v0.0.1",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "cc63fba56e75a22e5e41930894603723e14763dfc739058307ee7bdb28a7d2da"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/iris-contrib/pongo2@v0.0.1",
+      "externalReferences": [
+        {
+          "url": "https://github.com/iris-contrib/pongo2",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/iris-contrib/schema@v0.0.1",
+      "type": "library",
+      "name": "github.com/iris-contrib/schema",
+      "version": "v0.0.1",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d7483f5a7a1147e53e5d71d62811de372ffeb5998cda47005462ceb33fb26830"
+        }
+      ],
+      "purl": "pkg:golang/github.com/iris-contrib/schema@v0.0.1",
+      "externalReferences": [
+        {
+          "url": "https://github.com/iris-contrib/schema",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/ProtonMail/bcrypt@v0.0.0-20170924085257-7509ea014998",
+      "type": "library",
+      "name": "github.com/ProtonMail/bcrypt",
+      "version": "v0.0.0-20170924085257-7509ea014998",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "613dae57042245067109a69a8707dc813ab68f78faeb0d349ffdbb81bff3b9bb"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/ProtonMail/bcrypt@v0.0.0-20170924085257-7509ea014998",
+      "externalReferences": [
+        {
+          "url": "https://github.com/ProtonMail/bcrypt",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/jaytaylor/html2text@v0.0.0-20200412013138-3577fbdbcff7",
+      "type": "library",
+      "name": "github.com/jaytaylor/html2text",
+      "version": "v0.0.0-20200412013138-3577fbdbcff7",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "8347c01818ac1da110d1346ad6206f7a61517fef0011612604449289607756c7"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/jaytaylor/html2text@v0.0.0-20200412013138-3577fbdbcff7",
+      "externalReferences": [
+        {
+          "url": "https://github.com/jaytaylor/html2text",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/json-iterator/go@v1.1.9",
+      "type": "library",
+      "name": "github.com/json-iterator/go",
+      "version": "v1.1.9",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "f72cee77f1eddfaca0c1ab46c79e95c0266d948ff6003d794f55f6b234ae1a7b"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/json-iterator/go@v1.1.9",
+      "externalReferences": [
+        {
+          "url": "https://github.com/json-iterator/go",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/jtolds/gls@v4.20.0",
+      "type": "library",
+      "name": "github.com/jtolds/gls",
+      "version": "v4.20.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "0d61bff8c2de500d8311984d8f3cce613ec6aa4e2b4ecc63d11948dd914bf59f"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/jtolds/gls@v4.20.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/jtolds/gls",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/k0kubun/colorstring@v0.0.0-20150214042306-9440f1994b88",
+      "type": "library",
+      "name": "github.com/k0kubun/colorstring",
+      "version": "v0.0.0-20150214042306-9440f1994b88",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b82d507d29489e9405f8cd1aa3ae629a1c2a2a7cf7436cff77c3d6651310bc33"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/k0kubun/colorstring@v0.0.0-20150214042306-9440f1994b88",
+      "externalReferences": [
+        {
+          "url": "https://github.com/k0kubun/colorstring",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/kataras/golog@v0.0.10",
+      "type": "library",
+      "name": "github.com/kataras/golog",
+      "version": "v0.0.10",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "bd10d1526c1a71ca3fa660409bc81e2e7f2b1c475cfbd678340af94a1ed31bfe"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/kataras/golog@v0.0.10",
+      "externalReferences": [
+        {
+          "url": "https://github.com/kataras/golog",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/kataras/iris/v12@v12.1.8",
+      "type": "library",
+      "name": "github.com/kataras/iris/v12",
+      "version": "v12.1.8",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "3b78096ac8e6ed9c69c704c7f2d02966cbdfdbbe2c712190014a4d7b8edcdfb5"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/kataras/iris/v12@v12.1.8",
+      "externalReferences": [
+        {
+          "url": "https://github.com/kataras/iris/v12",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/kataras/neffos@v0.0.14",
+      "type": "library",
+      "name": "github.com/kataras/neffos",
+      "version": "v0.0.14",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a5d25a4ef506dcd41f78c6db54223c253d93e60a0f95dcb27d40763c97e1d41b"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/kataras/neffos@v0.0.14",
+      "externalReferences": [
+        {
+          "url": "https://github.com/kataras/neffos",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/kataras/pio@v0.0.2",
+      "type": "library",
+      "name": "github.com/kataras/pio",
+      "version": "v0.0.2",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e8d022fae3c9fd9ba277a9ab00a960a5b235d7fccafe5578076af159a24df7c6"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/kataras/pio@v0.0.2",
+      "externalReferences": [
+        {
+          "url": "https://github.com/kataras/pio",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/kataras/sitemap@v0.0.5",
+      "type": "library",
+      "name": "github.com/kataras/sitemap",
+      "version": "v0.0.5",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e0708e357e512e0572e86e11918395def28d7266bda76dfa2dd18e8a926c6851"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/kataras/sitemap@v0.0.5",
+      "externalReferences": [
+        {
+          "url": "https://github.com/kataras/sitemap",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/keybase/go-keychain@v0.0.0-20200502122510-cda31fe0c86d",
+      "type": "library",
+      "name": "github.com/keybase/go-keychain",
+      "version": "v0.0.0-20200502122510-cda31fe0c86d",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "8158e10427d51a5df6448068a0e00dcdfc3ed14a97f0753ec8f94cbfcbf2a5c8"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/keybase/go-keychain@v0.0.0-20200502122510-cda31fe0c86d",
+      "externalReferences": [
+        {
+          "url": "https://github.com/keybase/go-keychain",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/keybase/go.dbus@v0.0.0-20200324223359-a94be52c0b03",
+      "type": "library",
+      "name": "github.com/keybase/go.dbus",
+      "version": "v0.0.0-20200324223359-a94be52c0b03",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "93dac2aae702b0fa4128387d803c24dd4e3a4dc35dee3a4a6a179df491880866"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-2-Clause",
+            "name": "BSD 2-Clause \"Simplified\" License",
+            "url": "https://spdx.org/licenses/BSD-2-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/keybase/go.dbus@v0.0.0-20200324223359-a94be52c0b03",
+      "externalReferences": [
+        {
+          "url": "https://github.com/keybase/go.dbus",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/klauspost/compress@v1.9.7",
+      "type": "library",
+      "name": "github.com/klauspost/compress",
+      "version": "v1.9.7",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "8585b580ff78254980841b49f8b373e4ccbe801a1b0f13d1d6256e2ae836e9a0"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/klauspost/compress@v1.9.7",
+      "externalReferences": [
+        {
+          "url": "https://github.com/klauspost/compress",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/klauspost/cpuid@v1.2.1",
+      "type": "library",
+      "name": "github.com/klauspost/cpuid",
+      "version": "v1.2.1",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "bc98be3bf9cc745b74bea9bc359048eb0cc02d6740d97f9e822d2880dcab0bfc"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/klauspost/cpuid@v1.2.1",
+      "externalReferences": [
+        {
+          "url": "https://github.com/klauspost/cpuid",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/konsorten/go-windows-terminal-sequences@v1.0.2",
+      "type": "library",
+      "name": "github.com/konsorten/go-windows-terminal-sequences",
+      "version": "v1.0.2",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "0c1d7b6a0d7d92bc7d085b33e28dde9d3acf5f22170a5fb68825c7fda300a7db"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/konsorten/go-windows-terminal-sequences@v1.0.2",
+      "externalReferences": [
+        {
+          "url": "https://github.com/konsorten/go-windows-terminal-sequences",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/kr/pretty@v0.1.0",
+      "type": "library",
+      "name": "github.com/kr/pretty",
+      "version": "v0.1.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "2ff0b0374cdead90e644551aa523e2b64e9ff90dfed336b5ad093356e3223052"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/kr/pretty@v0.1.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/kr/pretty",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/kr/pty@v1.1.1",
+      "type": "library",
+      "name": "github.com/kr/pty",
+      "version": "v1.1.1",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "564a1723049ba01a6793df4efca15ab801082ee347bf90d514a64c04dfe0520c"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/kr/pty@v1.1.1",
+      "externalReferences": [
+        {
+          "url": "https://github.com/kr/pty",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/kr/text@v0.2.0",
+      "type": "library",
+      "name": "github.com/kr/text",
+      "version": "v0.2.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e4dc7461ad19a98db2815dfae90cedbab1c8d7726af79029715689061a52f806"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/kr/text@v0.2.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/kr/text",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/labstack/echo/v4@v4.1.11",
+      "type": "library",
+      "name": "github.com/labstack/echo/v4",
+      "version": "v4.1.11",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "cf4059a00ad8e05a9da54125fb0947a78867affa1247a3139909aff0e1d2a30c"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/labstack/echo/v4@v4.1.11",
+      "externalReferences": [
+        {
+          "url": "https://github.com/labstack/echo/v4",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/labstack/gommon@v0.3.0",
+      "type": "library",
+      "name": "github.com/labstack/gommon",
+      "version": "v0.3.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "24478ed1bbdcefc3ca7721f19684ca885f010f9886ac7f13e8c49e1af4a0a1bd"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/labstack/gommon@v0.3.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/labstack/gommon",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/logrusorgru/aurora@v2.0.3",
+      "type": "library",
+      "name": "github.com/logrusorgru/aurora",
+      "version": "v2.0.3",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "2dff73b09ee12bc6bd7e6adc7f970c0337de1439857bdb82bb555526f0382c32"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Unlicense",
+            "name": "The Unlicense",
+            "url": "https://spdx.org/licenses/Unlicense.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/logrusorgru/aurora@v2.0.3",
+      "externalReferences": [
+        {
+          "url": "https://github.com/logrusorgru/aurora",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/magiconair/properties@v1.8.0",
+      "type": "library",
+      "name": "github.com/magiconair/properties",
+      "version": "v1.8.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "2cb8179ac85e5de46850e04e8edc0f40258862a33f2d4d5ac83b4378f7ab45c6"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-2-Clause",
+            "name": "BSD 2-Clause \"Simplified\" License",
+            "url": "https://spdx.org/licenses/BSD-2-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/magiconair/properties@v1.8.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/magiconair/properties",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/martinlindhe/base36@v1.1.0",
+      "type": "library",
+      "name": "github.com/martinlindhe/base36",
+      "version": "v1.1.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "708c2fbf062c7bfd3ed429143d81f966f548606dc9ac82e640421b2ee6abd366"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/martinlindhe/base36@v1.1.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/martinlindhe/base36",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/mattn/go-colorable@v0.1.4",
+      "type": "library",
+      "name": "github.com/mattn/go-colorable",
+      "version": "v0.1.4",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b276cf2c1f1f55f53d8b06dba37d133ed6cb473c16bba6894ba5e1e1e69abe20"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/mattn/go-colorable@v0.1.4",
+      "externalReferences": [
+        {
+          "url": "https://github.com/mattn/go-colorable",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/mattn/go-isatty@v0.0.11",
+      "type": "library",
+      "name": "github.com/mattn/go-isatty",
+      "version": "v0.0.11",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "1713ce4c536a1a4b835068b71ffaa451b40ee198816b66eb2aae6bd25f1319e3"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/mattn/go-isatty@v0.0.11",
+      "externalReferences": [
+        {
+          "url": "https://github.com/mattn/go-isatty",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/mattn/go-runewidth@v0.0.9",
+      "type": "library",
+      "name": "github.com/mattn/go-runewidth",
+      "version": "v0.0.9",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "2e6f7de5fdeb7f176977a4d29ae5421d56ff421ba9b97958afcb0223f41d13ed"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/mattn/go-runewidth@v0.0.9",
+      "externalReferences": [
+        {
+          "url": "https://github.com/mattn/go-runewidth",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/mattn/goveralls@v0.0.2",
+      "type": "library",
+      "name": "github.com/mattn/goveralls",
+      "version": "v0.0.2",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ede241e84aac3e1455c6fc045c69ea74edac248d0f4ecad6a13317124f7f3907"
+        }
+      ],
+      "purl": "pkg:golang/github.com/mattn/goveralls@v0.0.2",
+      "externalReferences": [
+        {
+          "url": "https://github.com/mattn/goveralls",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/mediocregopher/radix/v3@v3.4.2",
+      "type": "library",
+      "name": "github.com/mediocregopher/radix/v3",
+      "version": "v3.4.2",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "81a95b3c18c8c26c91120c0609f4043785fc9716c99ca058bab833f957dc4ad0"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/mediocregopher/radix/v3@v3.4.2",
+      "externalReferences": [
+        {
+          "url": "https://github.com/mediocregopher/radix/v3",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/microcosm-cc/bluemonday@v1.0.2",
+      "type": "library",
+      "name": "github.com/microcosm-cc/bluemonday",
+      "version": "v1.0.2",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e653df2d34c0bc06ed4b456a4fef78c8eb459c67d4598cb1d3e893a02dceb37b"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/microcosm-cc/bluemonday@v1.0.2",
+      "externalReferences": [
+        {
+          "url": "https://github.com/microcosm-cc/bluemonday",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/miekg/dns@v1.1.30",
+      "type": "library",
+      "name": "github.com/miekg/dns",
+      "version": "v1.1.30",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "430c3a16c7859fc3d17f0d3b8ee7aa217aa8766d092a288ab8ad037974aa7f2a"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/miekg/dns@v1.1.30",
+      "externalReferences": [
+        {
+          "url": "https://github.com/miekg/dns",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/mitchellh/go-homedir@v1.1.0",
+      "type": "library",
+      "name": "github.com/mitchellh/go-homedir",
+      "version": "v1.1.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "96e905f738971710c53e4035becaf9ce97355ee3c39ffc059edab9986fb81346"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/mitchellh/go-homedir@v1.1.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/mitchellh/go-homedir",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/mitchellh/mapstructure@v1.1.2",
+      "type": "library",
+      "name": "github.com/mitchellh/mapstructure",
+      "version": "v1.1.2",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "7e6358570aa749f07d99953a392d8ee86b1733ec1cb24643b8a433bcdd440de1"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/mitchellh/mapstructure@v1.1.2",
+      "externalReferences": [
+        {
+          "url": "https://github.com/mitchellh/mapstructure",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+      "type": "library",
+      "name": "github.com/modern-go/concurrent",
+      "version": "v0.0.0-20180306012644-bacd9c7ef1dd",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "4d12da67d703ff0f0f561f779ec3d76b556b43a8e5c0be6837c975e1095c35f8"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "name": "Apache License 2.0",
+            "url": "https://spdx.org/licenses/Apache-2.0.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+      "externalReferences": [
+        {
+          "url": "https://github.com/modern-go/concurrent",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.1",
+      "type": "library",
+      "name": "github.com/modern-go/reflect2",
+      "version": "v1.0.1",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "f5fe35dacfba4666172d665213355580f18aec2d8fa611e3e5126bbdfc7d0162"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "name": "Apache License 2.0",
+            "url": "https://spdx.org/licenses/Apache-2.0.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/modern-go/reflect2@v1.0.1",
+      "externalReferences": [
+        {
+          "url": "https://github.com/modern-go/reflect2",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/moul/http2curl@v1.0.0",
+      "type": "library",
+      "name": "github.com/moul/http2curl",
+      "version": "v1.0.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "751316a00b5bf9e3f13252e4ac26c0aa1e1394f1d7be8194490df6dfff596a1b"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/moul/http2curl@v1.0.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/moul/http2curl",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/nats-io/jwt@v0.3.0",
+      "type": "library",
+      "name": "github.com/nats-io/jwt",
+      "version": "v0.3.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "c5d9f3c0511357efa335ce16d66c3ffea1722466f60013a899b9992504b8f90a"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "name": "Apache License 2.0",
+            "url": "https://spdx.org/licenses/Apache-2.0.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/nats-io/jwt@v0.3.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/nats-io/jwt",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/nats-io/nats.go@v1.9.1",
+      "type": "library",
+      "name": "github.com/nats-io/nats.go",
+      "version": "v1.9.1",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "8a4dc76cb859d180012eda3b897f34a592cfc3fe9dc774fefbe3192702e732b4"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "name": "Apache License 2.0",
+            "url": "https://spdx.org/licenses/Apache-2.0.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/nats-io/nats.go@v1.9.1",
+      "externalReferences": [
+        {
+          "url": "https://github.com/nats-io/nats.go",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/nats-io/nkeys@v0.1.0",
+      "type": "library",
+      "name": "github.com/nats-io/nkeys",
+      "version": "v0.1.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a8c778fa944781daf59c00a5bbeda1ff66b91764e629c0b38c20dacd5811a17e"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "name": "Apache License 2.0",
+            "url": "https://spdx.org/licenses/Apache-2.0.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/nats-io/nkeys@v0.1.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/nats-io/nkeys",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/nats-io/nuid@v1.0.1",
+      "type": "library",
+      "name": "github.com/nats-io/nuid",
+      "version": "v1.0.1",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e6203c0d3f15eeaf162b611272fda969d35afeb4c449cd4a7673f0e130b6a5ac"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "name": "Apache License 2.0",
+            "url": "https://spdx.org/licenses/Apache-2.0.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/nats-io/nuid@v1.0.1",
+      "externalReferences": [
+        {
+          "url": "https://github.com/nats-io/nuid",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e",
+      "type": "library",
+      "name": "github.com/niemeyer/pretty",
+      "version": "v0.0.0-20200227124842-a10e7caefd8e",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "7c3e7b11147826d12ab166df3e1bf80cc880a47ca58a22b9c424cd5523e2680b"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e",
+      "externalReferences": [
+        {
+          "url": "https://github.com/niemeyer/pretty",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/nsf/jsondiff@v0.0.0-20200515183724-f29ed568f4ce",
+      "type": "library",
+      "name": "github.com/nsf/jsondiff",
+      "version": "v0.0.0-20200515183724-f29ed568f4ce",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "44f7257e06b648426680c9b3da4f8c83b728c19f32bf84ebab0f54b096f2ef9f"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/nsf/jsondiff@v0.0.0-20200515183724-f29ed568f4ce",
+      "externalReferences": [
+        {
+          "url": "https://github.com/nsf/jsondiff",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/olekukonko/tablewriter@v0.0.4",
+      "type": "library",
+      "name": "github.com/olekukonko/tablewriter",
+      "version": "v0.0.4",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "bc70ff6187b55a8968efc9281b6f7d7fb57f5404b4f1ce88a422e7f848dfff0f"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/olekukonko/tablewriter@v0.0.4",
+      "externalReferences": [
+        {
+          "url": "https://github.com/olekukonko/tablewriter",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/onsi/ginkgo@v1.10.3",
+      "type": "library",
+      "name": "github.com/onsi/ginkgo",
+      "version": "v1.10.3",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "3a8c5b8df5d5672a1dd5f99662123b484c9a0fc074d329cfdd3f83e468b21ce6"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/onsi/ginkgo@v1.10.3",
+      "externalReferences": [
+        {
+          "url": "https://github.com/onsi/ginkgo",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/onsi/gomega@v1.7.1",
+      "type": "library",
+      "name": "github.com/onsi/gomega",
+      "version": "v1.7.1",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "2b48dc442c0d40cdef146875a6932d0e1ffeec0a49ae395d957f1f0348c34cb4"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/onsi/gomega@v1.7.1",
+      "externalReferences": [
+        {
+          "url": "https://github.com/onsi/gomega",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/pelletier/go-toml@v1.2.0",
+      "type": "library",
+      "name": "github.com/pelletier/go-toml",
+      "version": "v1.2.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "4f9ccc18c2fad56a7e16571b5a34434fbc80c6124d0223cf2ce1440aad7cd737"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/pelletier/go-toml@v1.2.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/pelletier/go-toml",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/pingcap/errors@v0.11.4",
+      "type": "library",
+      "name": "github.com/pingcap/errors",
+      "version": "v0.11.4",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "945b9057fa1a50c19c0f6b6ab7ed3544e4a626cef9546d53a043a46486789c4e"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-2-Clause",
+            "name": "BSD 2-Clause \"Simplified\" License",
+            "url": "https://spdx.org/licenses/BSD-2-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/pingcap/errors@v0.11.4",
+      "externalReferences": [
+        {
+          "url": "https://github.com/pingcap/errors",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/pkg/errors@v0.9.1",
+      "type": "library",
+      "name": "github.com/pkg/errors",
+      "version": "v0.9.1",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "14404bc75cd2db5e28c298f2eeab017a2c5b51192e850030acae54c0b193c2de"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-2-Clause",
+            "name": "BSD 2-Clause \"Simplified\" License",
+            "url": "https://spdx.org/licenses/BSD-2-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/pkg/errors@v0.9.1",
+      "externalReferences": [
+        {
+          "url": "https://github.com/pkg/errors",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+      "type": "library",
+      "name": "github.com/pmezard/go-difflib",
+      "version": "v1.0.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e030700c4d0d1b24280476cb4183f04943e808c591e41133224fdfd6565b0103"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/pmezard/go-difflib",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/russross/blackfriday@v1.5.2",
+      "type": "library",
+      "name": "github.com/russross/blackfriday",
+      "version": "v1.5.2",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "1f2bc2d0045f9d906a9d7c00045792647a4abc91c925f3f3f3518db9e2e3d28a"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-2-Clause",
+            "name": "BSD 2-Clause \"Simplified\" License",
+            "url": "https://spdx.org/licenses/BSD-2-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/russross/blackfriday@v1.5.2",
+      "externalReferences": [
+        {
+          "url": "https://github.com/russross/blackfriday",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/russross/blackfriday/v2@v2.0.1",
+      "type": "library",
+      "name": "github.com/russross/blackfriday/v2",
+      "version": "v2.0.1",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "94fa9502d7be1ee1cd7e127fd0b0bdf04496473f1a7f2f6d33fd112bc9bda3e4"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-2-Clause",
+            "name": "BSD 2-Clause \"Simplified\" License",
+            "url": "https://spdx.org/licenses/BSD-2-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/russross/blackfriday/v2@v2.0.1",
+      "externalReferences": [
+        {
+          "url": "https://github.com/russross/blackfriday/v2",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/ryanuber/columnize@v2.1.0",
+      "type": "library",
+      "name": "github.com/ryanuber/columnize",
+      "version": "v2.1.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "67857b6becfe4e5a74ee5af8b920af2a90025f5420b85484816ee0a21db5f62c"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/ryanuber/columnize@v2.1.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/ryanuber/columnize",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/schollz/closestmatch@v2.1.0",
+      "type": "library",
+      "name": "github.com/schollz/closestmatch",
+      "version": "v2.1.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d6b425d6e1e57fc2a49546fd9d947fef0b40c2f06cbeb01a05c45164bd84556a"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/schollz/closestmatch@v2.1.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/schollz/closestmatch",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/sergi/go-diff@v1.0.0",
+      "type": "library",
+      "name": "github.com/sergi/go-diff",
+      "version": "v1.0.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "2a971adea44daddb8d9ce41e6b305dd32b1a2ab509888b88487c688244fd44f4"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/sergi/go-diff@v1.0.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/sergi/go-diff",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/shurcooL/sanitized_anchor_name@v1.0.0",
+      "type": "library",
+      "name": "github.com/shurcooL/sanitized_anchor_name",
+      "version": "v1.0.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "3dd9a808eeb0bdbb3eef2ac9c8c391b78fc1998e486322704bf90e896c7c987a"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/shurcooL/sanitized_anchor_name@v1.0.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/shurcooL/sanitized_anchor_name",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/sirupsen/logrus@v1.7.0",
+      "type": "library",
+      "name": "github.com/sirupsen/logrus",
+      "version": "v1.7.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "4a1ac3d54f69641d764d7d1c572d03b5e3e8087f7b2bc12d5fe9a0ed901152d3"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/sirupsen/logrus@v1.7.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/sirupsen/logrus",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/skratchdot/open-golang@v0.0.0-20200116055534-eef842397966",
+      "type": "library",
+      "name": "github.com/skratchdot/open-golang",
+      "version": "v0.0.0-20200116055534-eef842397966",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "24802eab71047fd7206d4e80b463cae024c6dd97fa08a30da9fd0c1d38200140"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/skratchdot/open-golang@v0.0.0-20200116055534-eef842397966",
+      "externalReferences": [
+        {
+          "url": "https://github.com/skratchdot/open-golang",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/smartystreets/assertions@v0.0.0-20180927180507-b2de0cb4f26d",
+      "type": "library",
+      "name": "github.com/smartystreets/assertions",
+      "version": "v0.0.0-20180927180507-b2de0cb4f26d",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "cc4f7290495643afcd6261dade3a66ff21e7238c52a1f3fe50fe92a631dc49e3"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/smartystreets/assertions@v0.0.0-20180927180507-b2de0cb4f26d",
+      "externalReferences": [
+        {
+          "url": "https://github.com/smartystreets/assertions",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/smartystreets/goconvey@v1.6.4",
+      "type": "library",
+      "name": "github.com/smartystreets/goconvey",
+      "version": "v1.6.4",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "7efd14f0550830f35fd4bf659c72ef2e182272b2150a112477320a62a6cd0bdb"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/smartystreets/goconvey@v1.6.4",
+      "externalReferences": [
+        {
+          "url": "https://github.com/smartystreets/goconvey",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/spf13/afero@v1.1.2",
+      "type": "library",
+      "name": "github.com/spf13/afero",
+      "version": "v1.1.2",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "9bcff3d6deff7f08f2b2341161b3f4443f9b50817ff2d2703dd119b08f370022"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "name": "Apache License 2.0",
+            "url": "https://spdx.org/licenses/Apache-2.0.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/spf13/afero@v1.1.2",
+      "externalReferences": [
+        {
+          "url": "https://github.com/spf13/afero",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/spf13/cast@v1.3.0",
+      "type": "library",
+      "name": "github.com/spf13/cast",
+      "version": "v1.3.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a207adfff095384a057b0a90c70af4123e728f2827a8692f820484fe0077e50f"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/spf13/cast@v1.3.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/spf13/cast",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/spf13/cobra@v0.0.5",
+      "type": "library",
+      "name": "github.com/spf13/cobra",
+      "version": "v0.0.5",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "7f407e2e42d7e83b66447d62b28340f554ed3542bd2bcc58776f0934d7cebffb"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "name": "Apache License 2.0",
+            "url": "https://spdx.org/licenses/Apache-2.0.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/spf13/cobra@v0.0.5",
+      "externalReferences": [
+        {
+          "url": "https://github.com/spf13/cobra",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/spf13/jwalterweatherman@v1.0.0",
+      "type": "library",
+      "name": "github.com/spf13/jwalterweatherman",
+      "version": "v1.0.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "5c711dc81f8472f96a65a99233864e30695cf77b7a01cb0112ef46735be7ef29"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/spf13/jwalterweatherman@v1.0.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/spf13/jwalterweatherman",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/spf13/pflag@v1.0.3",
+      "type": "library",
+      "name": "github.com/spf13/pflag",
+      "version": "v1.0.3",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ccf013e821b2eb05de43b36d4e76937ab7ca3ac57a57a17c6a01d71626b30e48"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/spf13/pflag@v1.0.3",
+      "externalReferences": [
+        {
+          "url": "https://github.com/spf13/pflag",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/spf13/viper@v1.3.2",
+      "type": "library",
+      "name": "github.com/spf13/viper",
+      "version": "v1.3.2",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "55416ac3929ca917fb8bbd063b35bb37e43bfa0c55064492aa25c1d76f894383"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/spf13/viper@v1.3.2",
+      "externalReferences": [
+        {
+          "url": "https://github.com/spf13/viper",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/ssor/bom@v0.0.0-20170718123548-6386211fdfcf",
+      "type": "library",
+      "name": "github.com/ssor/bom",
+      "version": "v0.0.0-20170718123548-6386211fdfcf",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a6f6d9d253345d63c1a942aa154f1c99abeca6f225f67ba5398c1dcba205451a"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/ssor/bom@v0.0.0-20170718123548-6386211fdfcf",
+      "externalReferences": [
+        {
+          "url": "https://github.com/ssor/bom",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/stretchr/objx@v0.2.0",
+      "type": "library",
+      "name": "github.com/stretchr/objx",
+      "version": "v0.2.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "1db8363627692c4f2f7840641194cbdc2be5914215cee53d8c3a6564ee78738f"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/stretchr/objx@v0.2.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/stretchr/objx",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/stretchr/testify@v1.6.1",
+      "type": "library",
+      "name": "github.com/stretchr/testify",
+      "version": "v1.6.1",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "8433ce1e6a4ea4fe3495250b72ac3b22b45bfeeef0e91a430bddfdf57ca835dd"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/stretchr/testify@v1.6.1",
+      "externalReferences": [
+        {
+          "url": "https://github.com/stretchr/testify",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/therecipe/qt@v0.0.0-20200701200531-7f61353ee73e",
+      "type": "library",
+      "name": "github.com/therecipe/qt",
+      "version": "v0.0.0-20200701200531-7f61353ee73e",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "1b40d0fd3450cab1198ed2e52f07af163691886f1e782325abd59743638ed9b9"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "LGPL-3.0",
+            "name": "GNU Lesser General Public License v3.0 only",
+            "url": "https://spdx.org/licenses/LGPL-3.0.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/therecipe/qt@v0.0.0-20200701200531-7f61353ee73e",
+      "externalReferences": [
+        {
+          "url": "https://github.com/therecipe/qt",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/ugorji/go@v1.1.7",
+      "type": "library",
+      "name": "github.com/ugorji/go",
+      "version": "v1.1.7",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ffaf20cb687ed6658caf0645783d644226a5752cc06f8df676da5e278da8bdda"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/ugorji/go@v1.1.7",
+      "externalReferences": [
+        {
+          "url": "https://github.com/ugorji/go",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/ugorji/go/codec@v1.1.7",
+      "type": "library",
+      "name": "github.com/ugorji/go/codec",
+      "version": "v1.1.7",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d92bd0695675a2e62baca2b0a12936a7377803d7af94a25bf684cbf8e68b512b"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/ugorji/go/codec@v1.1.7",
+      "externalReferences": [
+        {
+          "url": "https://github.com/ugorji/go/codec",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/urfave/cli/v2@v2.2.0",
+      "type": "library",
+      "name": "github.com/urfave/cli/v2",
+      "version": "v2.2.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "2534e733ac0acdd03426aa1d77deba3158f8bd66dbaae67291e5f5b0a6ded82e"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/urfave/cli/v2@v2.2.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/urfave/cli/v2",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/urfave/negroni@v1.0.0",
+      "type": "library",
+      "name": "github.com/urfave/negroni",
+      "version": "v1.0.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "9088a63a2b68ca9ab7e0aed31bb0d4689f64abf37839fbb08b5b23cf42a2a577"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/urfave/negroni@v1.0.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/urfave/negroni",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/valyala/bytebufferpool@v1.0.0",
+      "type": "library",
+      "name": "github.com/valyala/bytebufferpool",
+      "version": "v1.0.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "1aa0394c2ff4d36d58fdbf451b83a2f4caf7abb5d8c7a2a59736b014885c74fc"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/valyala/bytebufferpool@v1.0.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/valyala/bytebufferpool",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/valyala/fasthttp@v1.6.0",
+      "type": "library",
+      "name": "github.com/valyala/fasthttp",
+      "version": "v1.6.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b9617c9602a679a21ec1654fc22e0646ad8febe478e8881865dc56b4cf86b446"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/valyala/fasthttp@v1.6.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/valyala/fasthttp",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/valyala/fasttemplate@v1.0.1",
+      "type": "library",
+      "name": "github.com/valyala/fasttemplate",
+      "version": "v1.0.1",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b58f422623e73177f5111986d84c8aee035477e73a44a183d087d4f167544b3f"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/valyala/fasttemplate@v1.0.1",
+      "externalReferences": [
+        {
+          "url": "https://github.com/valyala/fasttemplate",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/valyala/tcplisten@v0.0.0-20161114210144-ceec8f93295a",
+      "type": "library",
+      "name": "github.com/valyala/tcplisten",
+      "version": "v0.0.0-20161114210144-ceec8f93295a",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d11e0d2c3443657e897268498178b91386fc5a0f388a16e650aa7f1af48f1337"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/valyala/tcplisten@v0.0.0-20161114210144-ceec8f93295a",
+      "externalReferences": [
+        {
+          "url": "https://github.com/valyala/tcplisten",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/vmihailenco/msgpack/v5@v5.1.3",
+      "type": "library",
+      "name": "github.com/vmihailenco/msgpack/v5",
+      "version": "v5.1.3",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "1700bd28f8f25bc3aa4d4a8cb7aad0c3dcb9d2f0367132d73ca09c04245b4208"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-2-Clause",
+            "name": "BSD 2-Clause \"Simplified\" License",
+            "url": "https://spdx.org/licenses/BSD-2-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/vmihailenco/msgpack/v5@v5.1.3",
+      "externalReferences": [
+        {
+          "url": "https://github.com/vmihailenco/msgpack/v5",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/vmihailenco/tagparser@v0.1.2",
+      "type": "library",
+      "name": "github.com/vmihailenco/tagparser",
+      "version": "v0.1.2",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "8278e856e07f9258c9e702021043a9c7df285cc58f2e3db61baed56ddd6a3ea7"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-2-Clause",
+            "name": "BSD 2-Clause \"Simplified\" License",
+            "url": "https://spdx.org/licenses/BSD-2-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/vmihailenco/tagparser@v0.1.2",
+      "externalReferences": [
+        {
+          "url": "https://github.com/vmihailenco/tagparser",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/xeipuuv/gojsonpointer@v0.0.0-20180127040702-4e3ac2762d5f",
+      "type": "library",
+      "name": "github.com/xeipuuv/gojsonpointer",
+      "version": "v0.0.0-20180127040702-4e3ac2762d5f",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "27d106a5c66d3f413fadaa2b08cc6514649306bb1295a0c67f78d4feabc01367"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "name": "Apache License 2.0",
+            "url": "https://spdx.org/licenses/Apache-2.0.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/xeipuuv/gojsonpointer@v0.0.0-20180127040702-4e3ac2762d5f",
+      "externalReferences": [
+        {
+          "url": "https://github.com/xeipuuv/gojsonpointer",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/xeipuuv/gojsonreference@v0.0.0-20180127040603-bd5ef7bd5415",
+      "type": "library",
+      "name": "github.com/xeipuuv/gojsonreference",
+      "version": "v0.0.0-20180127040603-bd5ef7bd5415",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "133256807a2fa27b7b36c723a40c57b0303c4bc04c62f7bc639fbb72e444ed1d"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "name": "Apache License 2.0",
+            "url": "https://spdx.org/licenses/Apache-2.0.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/xeipuuv/gojsonreference@v0.0.0-20180127040603-bd5ef7bd5415",
+      "externalReferences": [
+        {
+          "url": "https://github.com/xeipuuv/gojsonreference",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/xeipuuv/gojsonschema@v1.2.0",
+      "type": "library",
+      "name": "github.com/xeipuuv/gojsonschema",
+      "version": "v1.2.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "2e160946cf8be1f06d8d951fb92648286795bb4411cbc7b95e2ec3d7b53167be"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "name": "Apache License 2.0",
+            "url": "https://spdx.org/licenses/Apache-2.0.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/xeipuuv/gojsonschema@v1.2.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/xeipuuv/gojsonschema",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/xordataexchange/crypt@v0.0.3-0.20170626215501-b2862e3d0a77",
+      "type": "library",
+      "name": "github.com/xordataexchange/crypt",
+      "version": "v0.0.3-0.20170626215501-b2862e3d0a77",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "112152770619be47abbb746d76b62e7b3b4a84e0424800334b819ffa4d2d128c"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/xordataexchange/crypt@v0.0.3-0.20170626215501-b2862e3d0a77",
+      "externalReferences": [
+        {
+          "url": "https://github.com/xordataexchange/crypt",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/yalp/jsonpath@v0.0.0-20180802001716-5cc68e5049a0",
+      "type": "library",
+      "name": "github.com/yalp/jsonpath",
+      "version": "v0.0.0-20180802001716-5cc68e5049a0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e9f4614a380b0a44c3dc99c9c6f689e128fe4d86e5c3be7b6ea62065a3aae596"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/yalp/jsonpath@v0.0.0-20180802001716-5cc68e5049a0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/yalp/jsonpath",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/yudai/gojsondiff@v1.0.0",
+      "type": "library",
+      "name": "github.com/yudai/gojsondiff",
+      "version": "v1.0.0",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "dbb71b7ea5cb544275a3c23abf7cbd960f18766e7710aa875c038cc441a508e0"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/yudai/gojsondiff@v1.0.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/yudai/gojsondiff",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/yudai/golcs@v0.0.0-20170316035057-ecda9a501e82",
+      "type": "library",
+      "name": "github.com/yudai/golcs",
+      "version": "v0.0.0-20170316035057-ecda9a501e82",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "047c9f2a5432a9bb05379a7721f9c451db96bdbf62b38dbcfe735be4bdd4d353"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/yudai/golcs@v0.0.0-20170316035057-ecda9a501e82",
+      "externalReferences": [
+        {
+          "url": "https://github.com/yudai/golcs",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/yudai/pp@v2.0.1",
+      "type": "library",
+      "name": "github.com/yudai/pp",
+      "version": "v2.0.1",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "1299f78b400318def5807e58bf26b725c8d0ac5fcab8b1c798ffc31b0f73d730"
+        }
+      ],
+      "purl": "pkg:golang/github.com/yudai/pp@v2.0.1",
+      "externalReferences": [
+        {
+          "url": "https://github.com/yudai/pp",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/go.etcd.io/bbolt@v1.3.5",
+      "type": "library",
+      "name": "go.etcd.io/bbolt",
+      "version": "v1.3.5",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "5c0cf1f608c26f44718fb128a9c0a53c3d5de590716499348dbba83c77a706dd"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/go.etcd.io/bbolt@v1.3.5"
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/ProtonMail/crypto@v0.0.0-20201112115411-41db4ea0dd1c",
+      "type": "library",
+      "name": "github.com/ProtonMail/crypto",
+      "version": "v0.0.0-20201112115411-41db4ea0dd1c",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "89a55b10e9ec9121a0707ed74161c6e953e2ac70d1a187be21d774fdd9789bc0"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/ProtonMail/crypto@v0.0.0-20201112115411-41db4ea0dd1c",
+      "externalReferences": [
+        {
+          "url": "https://github.com/ProtonMail/crypto",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/golang.org/x/exp@v0.0.0-20190731235908-ec7cb31e5a56",
+      "type": "library",
+      "name": "golang.org/x/exp",
+      "version": "v0.0.0-20190731235908-ec7cb31e5a56",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "7acb64d6094e9d255e27db5d11965ce6600c0d993994d24dc89e83beb0644c45"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/golang.org/x/exp@v0.0.0-20190731235908-ec7cb31e5a56"
+    },
+    {
+      "bom-ref": "pkg:golang/golang.org/x/image@v0.0.0-20190802002840-cff245a6509b",
+      "type": "library",
+      "name": "golang.org/x/image",
+      "version": "v0.0.0-20190802002840-cff245a6509b",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "faa1291003e10d9d68d31ded1f365340302b9ce8b13b3183f475097dc83499be"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/golang.org/x/image@v0.0.0-20190802002840-cff245a6509b"
+    },
+    {
+      "bom-ref": "pkg:golang/golang.org/x/mobile@v0.0.0-20200801112145-973feb4309de",
+      "type": "library",
+      "name": "golang.org/x/mobile",
+      "version": "v0.0.0-20200801112145-973feb4309de",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "39527a41050101eb01f026628ca0d2b175fbc5856d521ae463483031f6e2e29e"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/golang.org/x/mobile@v0.0.0-20200801112145-973feb4309de"
+    },
+    {
+      "bom-ref": "pkg:golang/golang.org/x/mod@v0.1.1-0.20191209134235-331c550502dd",
+      "type": "library",
+      "name": "golang.org/x/mod",
+      "version": "v0.1.1-0.20191209134235-331c550502dd",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "78fb8d0bb3d9e8ee41ce03e7f5b65ac8445705d7d98d46285c47f90537c37e1f"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/golang.org/x/mod@v0.1.1-0.20191209134235-331c550502dd"
+    },
+    {
+      "bom-ref": "pkg:golang/golang.org/x/net@v0.0.0-20200707034311-ab3426394381",
+      "type": "library",
+      "name": "golang.org/x/net",
+      "version": "v0.0.0-20200707034311-ab3426394381",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "5576a4e48e9a1169805de42303e41267396036ba6af668dc7c37a6b9ec482ac5"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/golang.org/x/net@v0.0.0-20200707034311-ab3426394381"
+    },
+    {
+      "bom-ref": "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e",
+      "type": "library",
+      "name": "golang.org/x/sync",
+      "version": "v0.0.0-20190911185100-cd5d95a43a6e",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "bdcc466a84ecee457c9b9369f6e50d4229f806b2ceb61815ef6e7637c57e1706"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e"
+    },
+    {
+      "bom-ref": "pkg:golang/golang.org/x/sys@v0.0.0-20200323222414-85ca7c5b95cd",
+      "type": "library",
+      "name": "golang.org/x/sys",
+      "version": "v0.0.0-20200323222414-85ca7c5b95cd",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "c619b0caf8b3b93802daacfb665325b8fdb4b96f82dd19b4143fd62c35fcf3ce"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/golang.org/x/sys@v0.0.0-20200323222414-85ca7c5b95cd"
+    },
+    {
+      "bom-ref": "pkg:golang/golang.org/x/term@v0.0.0-20201117132131-f5c789dd3221",
+      "type": "library",
+      "name": "golang.org/x/term",
+      "version": "v0.0.0-20201117132131-f5c789dd3221",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "fd91dd6d5a5d47f8e4de0df4fdde3250bd0953d924b23f3e17f6e741454b1833"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/golang.org/x/term@v0.0.0-20201117132131-f5c789dd3221"
+    },
+    {
+      "bom-ref": "pkg:golang/golang.org/x/text@v0.3.5-0.20201125200606-c27b9fd57aec",
+      "type": "library",
+      "name": "golang.org/x/text",
+      "version": "v0.3.5-0.20201125200606-c27b9fd57aec",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "035a988e7789bb305967680807caddeb3adfaba97b4a810c27c12c4a294d2bf5"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/golang.org/x/text@v0.3.5-0.20201125200606-c27b9fd57aec"
+    },
+    {
+      "bom-ref": "pkg:golang/golang.org/x/tools@v0.0.0-20200117012304-6edc0a871e69",
+      "type": "library",
+      "name": "golang.org/x/tools",
+      "version": "v0.0.0-20200117012304-6edc0a871e69",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "c811c7c7e5d9a972419ba13191edcded5f609e5b325f1a023c46f5c957a78df9"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/golang.org/x/tools@v0.0.0-20200117012304-6edc0a871e69"
+    },
+    {
+      "bom-ref": "pkg:golang/golang.org/x/xerrors@v0.0.0-20191204190536-9bdfabe68543",
+      "type": "library",
+      "name": "golang.org/x/xerrors",
+      "version": "v0.0.0-20191204190536-9bdfabe68543",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "13b83ef46213ab4ee1a5fad1bbae885437b131a91fbf9d9e2d9d825c15a22abe"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/golang.org/x/xerrors@v0.0.0-20191204190536-9bdfabe68543"
+    },
+    {
+      "bom-ref": "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f",
+      "type": "library",
+      "name": "gopkg.in/check.v1",
+      "version": "v1.0.0-20200227125254-8fa46927fb4f",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "04bada1579e6adebf9953fb196296a707f172bdfe2d00b76c4a8d6938a7acec5"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-2-Clause",
+            "name": "BSD 2-Clause \"Simplified\" License",
+            "url": "https://spdx.org/licenses/BSD-2-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f",
+      "externalReferences": [
+        {
+          "url": "https://github.com/go-check/check",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/gopkg.in/fsnotify.v1@v1.4.7",
+      "type": "library",
+      "name": "gopkg.in/fsnotify.v1",
+      "version": "v1.4.7",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "c4e1cb5d9c15bc8f6186cf9c2caab9f88e689cebb040b850c22bbadf1c651ece"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/gopkg.in/fsnotify.v1@v1.4.7",
+      "externalReferences": [
+        {
+          "url": "https://github.com/go-fsnotify/fsnotify",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/gopkg.in/go-playground/assert.v1@v1.2.1",
+      "type": "library",
+      "name": "gopkg.in/go-playground/assert.v1",
+      "version": "v1.2.1",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "c6862e25513b293f393d85ab37bdf4460b8840ed1e3f35517c531769d22b5d33"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/gopkg.in/go-playground/assert.v1@v1.2.1",
+      "externalReferences": [
+        {
+          "url": "https://github.com/go-playground/assert",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/gopkg.in/go-playground/validator.v8@v8.18.2",
+      "type": "library",
+      "name": "gopkg.in/go-playground/validator.v8",
+      "version": "v8.18.2",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "9450780e8314e81eb6eb0f27cbbe8c57b557e96d951dcb76195388df182232b4"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/gopkg.in/go-playground/validator.v8@v8.18.2",
+      "externalReferences": [
+        {
+          "url": "https://github.com/go-playground/validator",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/gopkg.in/ini.v1@v1.51.1",
+      "type": "library",
+      "name": "gopkg.in/ini.v1",
+      "version": "v1.51.1",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "1b26e81ebe14a8c88b5326d88dddb6663408284244a60b4b5edb866d1db53a1a"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "name": "Apache License 2.0",
+            "url": "https://spdx.org/licenses/Apache-2.0.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/gopkg.in/ini.v1@v1.51.1",
+      "externalReferences": [
+        {
+          "url": "https://github.com/go-ini/ini",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/gopkg.in/mgo.v2@v2.0.0-20180705113604-9856a29383ce",
+      "type": "library",
+      "name": "gopkg.in/mgo.v2",
+      "version": "v2.0.0-20180705113604-9856a29383ce",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "c5c1168d586f6c3cbe9c73faee73c30e96d8ad8f882e57e7764e1b462a151da5"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-2-Clause",
+            "name": "BSD 2-Clause \"Simplified\" License",
+            "url": "https://spdx.org/licenses/BSD-2-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/gopkg.in/mgo.v2@v2.0.0-20180705113604-9856a29383ce",
+      "externalReferences": [
+        {
+          "url": "https://github.com/go-mgo/mgo",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7",
+      "type": "library",
+      "name": "gopkg.in/tomb.v1",
+      "version": "v1.0.0-20141024135613-dd632973f1e7",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b9118975c88e1da108af37b65bc43700a91ea4b4e1da13aba13edafbb7337dd4"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7",
+      "externalReferences": [
+        {
+          "url": "https://github.com/go-tomb/tomb",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/gopkg.in/yaml.v2@v2.2.8",
+      "type": "library",
+      "name": "gopkg.in/yaml.v2",
+      "version": "v2.2.8",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a1b37565a809494188d0493f2c19ae8f848d2cf7c89f2dcab0a168a7145d8f5d"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "name": "Apache License 2.0",
+            "url": "https://spdx.org/licenses/Apache-2.0.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/gopkg.in/yaml.v2@v2.2.8",
+      "externalReferences": [
+        {
+          "url": "https://github.com/go-yaml/yaml",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.0-20200313102051-9f266ea9e77c",
+      "type": "library",
+      "name": "gopkg.in/yaml.v3",
+      "version": "v3.0.0-20200313102051-9f266ea9e77c",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "7545301e4d90102a3feafa80e38aed859f227b641730d78a4531c2358da75efa"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "name": "Apache License 2.0",
+            "url": "https://spdx.org/licenses/Apache-2.0.html"
+          }
+        },
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/gopkg.in/yaml.v3@v3.0.0-20200313102051-9f266ea9e77c",
+      "externalReferences": [
+        {
+          "url": "https://github.com/go-yaml/yaml",
+          "type": "vcs"
+        }
+      ]
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "pkg:golang/github.com/0xAX/notificator@v0.0.0-20191016112426-3962a5ea8da1"
+    },
+    {
+      "ref": "pkg:golang/github.com/AndreasBriese/bbloom@v0.0.0-20190306092124-e2d15f34fcf9"
+    },
+    {
+      "ref": "pkg:golang/github.com/BurntSushi/toml@v0.3.1"
+    },
+    {
+      "ref": "pkg:golang/github.com/BurntSushi/xgb@v0.0.0-20160522181843-27f122750802"
+    },
+    {
+      "ref": "pkg:golang/github.com/CloudyKit/fastprinter@v0.0.0-20200109182630-33d98a066a53"
+    },
+    {
+      "ref": "pkg:golang/github.com/CloudyKit/jet/v3@v3.0.0",
+      "dependsOn": [
+        "pkg:golang/github.com/CloudyKit/fastprinter@v0.0.0-20200109182630-33d98a066a53"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/Joker/hpp@v1.0.0"
+    },
+    {
+      "ref": "pkg:golang/github.com/Masterminds/semver/v3@v3.1.0"
+    },
+    {
+      "ref": "pkg:golang/github.com/ProtonMail/go-autostart@v0.0.0-20181114175602-c5272053443a"
+    },
+    {
+      "ref": "pkg:golang/github.com/ProtonMail/go-crypto@v0.0.0-20201208171014-cdb7591792e2",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/term@v0.0.0-20201117132131-f5c789dd3221"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/ProtonMail/go-imap-id@v0.0.0-20190926060100-f94a56b9ecde"
+    },
+    {
+      "ref": "pkg:golang/github.com/ProtonMail/go-mime@v0.0.0-20190923161245-9b5a4261663a"
+    },
+    {
+      "ref": "pkg:golang/github.com/ProtonMail/go-rfc5322@v0.5.0",
+      "dependsOn": [
+        "pkg:golang/github.com/antlr/antlr4@v0.0.0-20201029161626-9a95f0cc3d7c",
+        "pkg:golang/github.com/sirupsen/logrus@v1.7.0",
+        "pkg:golang/github.com/stretchr/testify@v1.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/ProtonMail/go-vcard@v0.0.0-20180326232728-33aaa0a0c8a5"
+    },
+    {
+      "ref": "pkg:golang/github.com/ProtonMail/gopenpgp/v2@v2.1.3",
+      "dependsOn": [
+        "pkg:golang/github.com/ProtonMail/go-crypto@v0.0.0-20201208171014-cdb7591792e2",
+        "pkg:golang/github.com/ProtonMail/go-mime@v0.0.0-20190923161245-9b5a4261663a",
+        "pkg:golang/golang.org/x/mobile@v0.0.0-20200801112145-973feb4309de"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/PuerkitoBio/goquery@v1.5.1",
+      "dependsOn": [
+        "pkg:golang/github.com/andybalholm/cascadia@v1.1.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/Shopify/goreferrer@v0.0.0-20181106222321-ec9c9a553398"
+    },
+    {
+      "ref": "pkg:golang/github.com/abiosoft/ishell@v2.0.0"
+    },
+    {
+      "ref": "pkg:golang/github.com/abiosoft/readline@v0.0.0-20180607040430-155bce2042db"
+    },
+    {
+      "ref": "pkg:golang/github.com/ajg/form@v1.5.1"
+    },
+    {
+      "ref": "pkg:golang/github.com/allan-simon/go-singleinstance@v0.0.0-20160830203053-79edcfdc2dfc"
+    },
+    {
+      "ref": "pkg:golang/github.com/andybalholm/cascadia@v1.1.0"
+    },
+    {
+      "ref": "pkg:golang/github.com/antlr/antlr4@v0.0.0-20201029161626-9a95f0cc3d7c"
+    },
+    {
+      "ref": "pkg:golang/github.com/armon/consul-api@v0.0.0-20180202201655-eb2c6b5be1b6"
+    },
+    {
+      "ref": "pkg:golang/github.com/aymerick/raymond@v2.0.3-0.20180322193309-b565731e1464"
+    },
+    {
+      "ref": "pkg:golang/github.com/chzyer/logex@v1.1.10"
+    },
+    {
+      "ref": "pkg:golang/github.com/chzyer/test@v0.0.0-20180213035817-a1ea475d72b1"
+    },
+    {
+      "ref": "pkg:golang/github.com/codegangsta/inject@v0.0.0-20150114235600-33e0aa1cb7c0"
+    },
+    {
+      "ref": "pkg:golang/github.com/coreos/etcd@v3.3.10"
+    },
+    {
+      "ref": "pkg:golang/github.com/coreos/go-etcd@v2.0.0"
+    },
+    {
+      "ref": "pkg:golang/github.com/coreos/go-semver@v0.2.0"
+    },
+    {
+      "ref": "pkg:golang/github.com/cpuguy83/go-md2man@v1.0.10",
+      "dependsOn": [
+        "pkg:golang/github.com/russross/blackfriday@v1.5.2"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/cpuguy83/go-md2man/v2@v2.0.0-20190314233015-f79a8a8ca69d",
+      "dependsOn": [
+        "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+        "pkg:golang/github.com/russross/blackfriday/v2@v2.0.1",
+        "pkg:golang/github.com/shurcooL/sanitized_anchor_name@v1.0.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/creack/pty@v1.1.9"
+    },
+    {
+      "ref": "pkg:golang/github.com/cucumber/godog@v0.8.1"
+    },
+    {
+      "ref": "pkg:golang/github.com/danieljoos/wincred@v1.1.0"
+    },
+    {
+      "ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.1"
+    },
+    {
+      "ref": "pkg:golang/github.com/dgraph-io/badger@v1.6.0",
+      "dependsOn": [
+        "pkg:golang/github.com/AndreasBriese/bbloom@v0.0.0-20190306092124-e2d15f34fcf9",
+        "pkg:golang/github.com/dgryski/go-farm@v0.0.0-20190423205320-6a90982ecee2",
+        "pkg:golang/github.com/dustin/go-humanize@v1.0.0",
+        "pkg:golang/github.com/golang/protobuf@v1.3.1",
+        "pkg:golang/github.com/spf13/cobra@v0.0.5"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/dgrijalva/jwt-go@v3.2.0"
+    },
+    {
+      "ref": "pkg:golang/github.com/dgryski/go-farm@v0.0.0-20190423205320-6a90982ecee2"
+    },
+    {
+      "ref": "pkg:golang/github.com/ProtonMail/docker-credential-helpers@v1.1.0",
+      "dependsOn": [
+        "pkg:golang/github.com/danieljoos/wincred@v1.1.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/dustin/go-humanize@v1.0.0"
+    },
+    {
+      "ref": "pkg:golang/github.com/eknkc/amber@v0.0.0-20171010120322-cdade1c07385"
+    },
+    {
+      "ref": "pkg:golang/github.com/ProtonMail/go-imap@v0.0.0-20201228133358-4db68cea0cac"
+    },
+    {
+      "ref": "pkg:golang/github.com/emersion/go-imap-appendlimit@v0.0.0-20190308131241-25671c986a6a"
+    },
+    {
+      "ref": "pkg:golang/github.com/emersion/go-imap-idle@v0.0.0-20200601154248-f05f54664cc4"
+    },
+    {
+      "ref": "pkg:golang/github.com/emersion/go-imap-move@v0.0.0-20190710073258-6e5a51a5b342"
+    },
+    {
+      "ref": "pkg:golang/github.com/emersion/go-imap-quota@v0.0.0-20200423100218-dcfd1b7d2b41"
+    },
+    {
+      "ref": "pkg:golang/github.com/emersion/go-imap-unselect@v0.0.0-20171113212723-b985794e5f26"
+    },
+    {
+      "ref": "pkg:golang/github.com/emersion/go-mbox@v1.0.2"
+    },
+    {
+      "ref": "pkg:golang/github.com/emersion/go-message@v0.12.1-0.20201221184100-40c3f864532b",
+      "dependsOn": [
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+        "pkg:golang/github.com/emersion/go-textwrapper@v0.0.0-20200911093747-65d896831594",
+        "pkg:golang/github.com/martinlindhe/base36@v1.1.0",
+        "pkg:golang/golang.org/x/text@v0.3.5-0.20201125200606-c27b9fd57aec"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/emersion/go-sasl@v0.0.0-20200509203442-7bfe0ed36a21"
+    },
+    {
+      "ref": "pkg:golang/github.com/emersion/go-smtp@v0.14.0",
+      "dependsOn": [
+        "pkg:golang/github.com/emersion/go-sasl@v0.0.0-20200509203442-7bfe0ed36a21"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/emersion/go-textwrapper@v0.0.0-20200911093747-65d896831594"
+    },
+    {
+      "ref": "pkg:golang/github.com/emersion/go-vcard@v0.0.0-20190105225839-8856043f13c5"
+    },
+    {
+      "ref": "pkg:golang/github.com/etcd-io/bbolt@v1.3.3"
+    },
+    {
+      "ref": "pkg:golang/github.com/fasthttp-contrib/websocket@v0.0.0-20160511215533-1f3b11f56072"
+    },
+    {
+      "ref": "pkg:golang/github.com/fatih/color@v1.9.0",
+      "dependsOn": [
+        "pkg:golang/github.com/mattn/go-colorable@v0.1.4",
+        "pkg:golang/github.com/mattn/go-isatty@v0.0.11"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/fatih/structs@v1.1.0"
+    },
+    {
+      "ref": "pkg:golang/github.com/flynn-archive/go-shlex@v0.0.0-20150515145356-3f9db97f8568"
+    },
+    {
+      "ref": "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7"
+    },
+    {
+      "ref": "pkg:golang/github.com/gavv/httpexpect@v2.0.0"
+    },
+    {
+      "ref": "pkg:golang/github.com/getsentry/sentry-go@v0.8.0",
+      "dependsOn": [
+        "pkg:golang/github.com/ajg/form@v1.5.1",
+        "pkg:golang/github.com/codegangsta/inject@v0.0.0-20150114235600-33e0aa1cb7c0",
+        "pkg:golang/github.com/fasthttp-contrib/websocket@v0.0.0-20160511215533-1f3b11f56072",
+        "pkg:golang/github.com/gin-gonic/gin@v1.4.0",
+        "pkg:golang/github.com/go-errors/errors@v1.0.1",
+        "pkg:golang/github.com/go-martini/martini@v0.0.0-20170121215854-22fa46961aab",
+        "pkg:golang/github.com/google/go-querystring@v1.0.0",
+        "pkg:golang/github.com/imkira/go-interpol@v1.1.0",
+        "pkg:golang/github.com/k0kubun/colorstring@v0.0.0-20150214042306-9440f1994b88",
+        "pkg:golang/github.com/kataras/iris/v12@v12.1.8",
+        "pkg:golang/github.com/labstack/echo/v4@v4.1.11",
+        "pkg:golang/github.com/moul/http2curl@v1.0.0",
+        "pkg:golang/github.com/onsi/ginkgo@v1.10.3",
+        "pkg:golang/github.com/onsi/gomega@v1.7.1",
+        "pkg:golang/github.com/pingcap/errors@v0.11.4",
+        "pkg:golang/github.com/sergi/go-diff@v1.0.0",
+        "pkg:golang/github.com/shurcooL/sanitized_anchor_name@v1.0.0",
+        "pkg:golang/github.com/smartystreets/goconvey@v1.6.4",
+        "pkg:golang/github.com/ugorji/go@v1.1.7",
+        "pkg:golang/github.com/urfave/negroni@v1.0.0",
+        "pkg:golang/github.com/valyala/fasthttp@v1.6.0",
+        "pkg:golang/github.com/xeipuuv/gojsonschema@v1.2.0",
+        "pkg:golang/github.com/yalp/jsonpath@v0.0.0-20180802001716-5cc68e5049a0",
+        "pkg:golang/github.com/yudai/gojsondiff@v1.0.0",
+        "pkg:golang/github.com/yudai/golcs@v0.0.0-20170316035057-ecda9a501e82",
+        "pkg:golang/github.com/yudai/pp@v2.0.1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/gin-contrib/sse@v0.0.0-20190301062529-5545eab6dad3"
+    },
+    {
+      "ref": "pkg:golang/github.com/gin-gonic/gin@v1.4.0",
+      "dependsOn": [
+        "pkg:golang/github.com/gin-contrib/sse@v0.0.0-20190301062529-5545eab6dad3",
+        "pkg:golang/github.com/golang/protobuf@v1.3.1",
+        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+        "pkg:golang/github.com/modern-go/reflect2@v1.0.1",
+        "pkg:golang/gopkg.in/go-playground/assert.v1@v1.2.1",
+        "pkg:golang/gopkg.in/go-playground/validator.v8@v8.18.2"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/go-check/check@v0.0.0-20180628173108-788fd7840127"
+    },
+    {
+      "ref": "pkg:golang/github.com/go-errors/errors@v1.0.1"
+    },
+    {
+      "ref": "pkg:golang/github.com/go-martini/martini@v0.0.0-20170121215854-22fa46961aab"
+    },
+    {
+      "ref": "pkg:golang/github.com/go-resty/resty/v2@v2.3.0"
+    },
+    {
+      "ref": "pkg:golang/github.com/gobwas/httphead@v0.0.0-20180130184737-2c6c146eadee"
+    },
+    {
+      "ref": "pkg:golang/github.com/gobwas/pool@v0.2.0"
+    },
+    {
+      "ref": "pkg:golang/github.com/gobwas/ws@v1.0.2"
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/mock@v1.4.4"
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/protobuf@v1.3.1"
+    },
+    {
+      "ref": "pkg:golang/github.com/gomodule/redigo@v1.7.1-0.20190724094224-574c33c3df38"
+    },
+    {
+      "ref": "pkg:golang/github.com/google/go-cmp@v0.5.1",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/xerrors@v0.0.0-20191204190536-9bdfabe68543"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/google/go-querystring@v1.0.0"
+    },
+    {
+      "ref": "pkg:golang/github.com/google/gofuzz@v1.0.0"
+    },
+    {
+      "ref": "pkg:golang/github.com/google/uuid@v1.1.1"
+    },
+    {
+      "ref": "pkg:golang/github.com/gopherjs/gopherjs@v0.0.0-20190430165422-3e4dfb77656c"
+    },
+    {
+      "ref": "pkg:golang/github.com/gorilla/websocket@v1.4.1"
+    },
+    {
+      "ref": "pkg:golang/github.com/hashicorp/errwrap@v1.0.0"
+    },
+    {
+      "ref": "pkg:golang/github.com/hashicorp/go-multierror@v1.1.0",
+      "dependsOn": [
+        "pkg:golang/github.com/hashicorp/errwrap@v1.0.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/hashicorp/go-version@v1.2.0"
+    },
+    {
+      "ref": "pkg:golang/github.com/hashicorp/hcl@v1.0.0",
+      "dependsOn": [
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/hpcloud/tail@v1.0.0"
+    },
+    {
+      "ref": "pkg:golang/github.com/imkira/go-interpol@v1.1.0"
+    },
+    {
+      "ref": "pkg:golang/github.com/inconshreveable/mousetrap@v1.0.0"
+    },
+    {
+      "ref": "pkg:golang/github.com/iris-contrib/blackfriday@v2.0.0"
+    },
+    {
+      "ref": "pkg:golang/github.com/iris-contrib/go.uuid@v2.0.0"
+    },
+    {
+      "ref": "pkg:golang/github.com/iris-contrib/jade@v1.1.3",
+      "dependsOn": [
+        "pkg:golang/github.com/Joker/hpp@v1.0.0",
+        "pkg:golang/github.com/valyala/bytebufferpool@v1.0.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/iris-contrib/pongo2@v0.0.1",
+      "dependsOn": [
+        "pkg:golang/github.com/go-check/check@v0.0.0-20180628173108-788fd7840127",
+        "pkg:golang/github.com/kr/pretty@v0.1.0",
+        "pkg:golang/github.com/mattn/goveralls@v0.0.2",
+        "pkg:golang/gopkg.in/mgo.v2@v2.0.0-20180705113604-9856a29383ce"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/iris-contrib/schema@v0.0.1"
+    },
+    {
+      "ref": "pkg:golang/github.com/ProtonMail/bcrypt@v0.0.0-20170924085257-7509ea014998"
+    },
+    {
+      "ref": "pkg:golang/github.com/jaytaylor/html2text@v0.0.0-20200412013138-3577fbdbcff7"
+    },
+    {
+      "ref": "pkg:golang/github.com/json-iterator/go@v1.1.9",
+      "dependsOn": [
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+        "pkg:golang/github.com/google/gofuzz@v1.0.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/jtolds/gls@v4.20.0"
+    },
+    {
+      "ref": "pkg:golang/github.com/k0kubun/colorstring@v0.0.0-20150214042306-9440f1994b88"
+    },
+    {
+      "ref": "pkg:golang/github.com/kataras/golog@v0.0.10",
+      "dependsOn": [
+        "pkg:golang/github.com/kataras/pio@v0.0.2"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/kataras/iris/v12@v12.1.8",
+      "dependsOn": [
+        "pkg:golang/github.com/BurntSushi/toml@v0.3.1",
+        "pkg:golang/github.com/CloudyKit/jet/v3@v3.0.0",
+        "pkg:golang/github.com/Shopify/goreferrer@v0.0.0-20181106222321-ec9c9a553398",
+        "pkg:golang/github.com/aymerick/raymond@v2.0.3-0.20180322193309-b565731e1464",
+        "pkg:golang/github.com/dgraph-io/badger@v1.6.0",
+        "pkg:golang/github.com/eknkc/amber@v0.0.0-20171010120322-cdade1c07385",
+        "pkg:golang/github.com/etcd-io/bbolt@v1.3.3",
+        "pkg:golang/github.com/fatih/structs@v1.1.0",
+        "pkg:golang/github.com/gavv/httpexpect@v2.0.0",
+        "pkg:golang/github.com/gomodule/redigo@v1.7.1-0.20190724094224-574c33c3df38",
+        "pkg:golang/github.com/hashicorp/go-version@v1.2.0",
+        "pkg:golang/github.com/iris-contrib/blackfriday@v2.0.0",
+        "pkg:golang/github.com/iris-contrib/go.uuid@v2.0.0",
+        "pkg:golang/github.com/iris-contrib/pongo2@v0.0.1",
+        "pkg:golang/github.com/iris-contrib/schema@v0.0.1",
+        "pkg:golang/github.com/iris-contrib/jade@v1.1.3",
+        "pkg:golang/github.com/json-iterator/go@v1.1.9",
+        "pkg:golang/github.com/kataras/golog@v0.0.10",
+        "pkg:golang/github.com/kataras/neffos@v0.0.14",
+        "pkg:golang/github.com/kataras/sitemap@v0.0.5",
+        "pkg:golang/github.com/klauspost/compress@v1.9.7",
+        "pkg:golang/github.com/mediocregopher/radix/v3@v3.4.2",
+        "pkg:golang/github.com/microcosm-cc/bluemonday@v1.0.2",
+        "pkg:golang/github.com/ryanuber/columnize@v2.1.0",
+        "pkg:golang/github.com/schollz/closestmatch@v2.1.0",
+        "pkg:golang/gopkg.in/ini.v1@v1.51.1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/kataras/neffos@v0.0.14",
+      "dependsOn": [
+        "pkg:golang/github.com/gobwas/httphead@v0.0.0-20180130184737-2c6c146eadee",
+        "pkg:golang/github.com/gobwas/pool@v0.2.0",
+        "pkg:golang/github.com/gobwas/ws@v1.0.2",
+        "pkg:golang/github.com/gorilla/websocket@v1.4.1",
+        "pkg:golang/github.com/iris-contrib/go.uuid@v2.0.0",
+        "pkg:golang/github.com/mediocregopher/radix/v3@v3.4.2",
+        "pkg:golang/github.com/nats-io/nats.go@v1.9.1",
+        "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/kataras/pio@v0.0.2"
+    },
+    {
+      "ref": "pkg:golang/github.com/kataras/sitemap@v0.0.5"
+    },
+    {
+      "ref": "pkg:golang/github.com/keybase/go-keychain@v0.0.0-20200502122510-cda31fe0c86d",
+      "dependsOn": [
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+        "pkg:golang/github.com/keybase/go.dbus@v0.0.0-20200324223359-a94be52c0b03",
+        "pkg:golang/github.com/kr/text@v0.2.0",
+        "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e",
+        "pkg:golang/github.com/pkg/errors@v0.9.1",
+        "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f",
+        "pkg:golang/gopkg.in/yaml.v2@v2.2.8"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/keybase/go.dbus@v0.0.0-20200324223359-a94be52c0b03"
+    },
+    {
+      "ref": "pkg:golang/github.com/klauspost/compress@v1.9.7"
+    },
+    {
+      "ref": "pkg:golang/github.com/klauspost/cpuid@v1.2.1"
+    },
+    {
+      "ref": "pkg:golang/github.com/konsorten/go-windows-terminal-sequences@v1.0.2"
+    },
+    {
+      "ref": "pkg:golang/github.com/kr/pretty@v0.1.0"
+    },
+    {
+      "ref": "pkg:golang/github.com/kr/pty@v1.1.1"
+    },
+    {
+      "ref": "pkg:golang/github.com/kr/text@v0.2.0",
+      "dependsOn": [
+        "pkg:golang/github.com/creack/pty@v1.1.9"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/labstack/echo/v4@v4.1.11",
+      "dependsOn": [
+        "pkg:golang/github.com/dgrijalva/jwt-go@v3.2.0",
+        "pkg:golang/github.com/labstack/gommon@v0.3.0",
+        "pkg:golang/github.com/valyala/fasttemplate@v1.0.1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/labstack/gommon@v0.3.0",
+      "dependsOn": [
+        "pkg:golang/github.com/valyala/fasttemplate@v1.0.1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/logrusorgru/aurora@v2.0.3"
+    },
+    {
+      "ref": "pkg:golang/github.com/magiconair/properties@v1.8.0"
+    },
+    {
+      "ref": "pkg:golang/github.com/martinlindhe/base36@v1.1.0"
+    },
+    {
+      "ref": "pkg:golang/github.com/mattn/go-colorable@v0.1.4"
+    },
+    {
+      "ref": "pkg:golang/github.com/mattn/go-isatty@v0.0.11"
+    },
+    {
+      "ref": "pkg:golang/github.com/mattn/go-runewidth@v0.0.9"
+    },
+    {
+      "ref": "pkg:golang/github.com/mattn/goveralls@v0.0.2"
+    },
+    {
+      "ref": "pkg:golang/github.com/mediocregopher/radix/v3@v3.4.2",
+      "dependsOn": [
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+        "pkg:golang/github.com/pmezard/go-difflib@v1.0.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/microcosm-cc/bluemonday@v1.0.2"
+    },
+    {
+      "ref": "pkg:golang/github.com/miekg/dns@v1.1.30"
+    },
+    {
+      "ref": "pkg:golang/github.com/mitchellh/go-homedir@v1.1.0"
+    },
+    {
+      "ref": "pkg:golang/github.com/mitchellh/mapstructure@v1.1.2"
+    },
+    {
+      "ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd"
+    },
+    {
+      "ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.1"
+    },
+    {
+      "ref": "pkg:golang/github.com/moul/http2curl@v1.0.0"
+    },
+    {
+      "ref": "pkg:golang/github.com/nats-io/jwt@v0.3.0",
+      "dependsOn": [
+        "pkg:golang/github.com/nats-io/nkeys@v0.1.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/nats-io/nats.go@v1.9.1",
+      "dependsOn": [
+        "pkg:golang/github.com/nats-io/jwt@v0.3.0",
+        "pkg:golang/github.com/nats-io/nkeys@v0.1.0",
+        "pkg:golang/github.com/nats-io/nuid@v1.0.1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/nats-io/nkeys@v0.1.0"
+    },
+    {
+      "ref": "pkg:golang/github.com/nats-io/nuid@v1.0.1"
+    },
+    {
+      "ref": "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e"
+    },
+    {
+      "ref": "pkg:golang/github.com/nsf/jsondiff@v0.0.0-20200515183724-f29ed568f4ce"
+    },
+    {
+      "ref": "pkg:golang/github.com/olekukonko/tablewriter@v0.0.4"
+    },
+    {
+      "ref": "pkg:golang/github.com/onsi/ginkgo@v1.10.3"
+    },
+    {
+      "ref": "pkg:golang/github.com/onsi/gomega@v1.7.1",
+      "dependsOn": [
+        "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7",
+        "pkg:golang/github.com/hpcloud/tail@v1.0.0",
+        "pkg:golang/gopkg.in/fsnotify.v1@v1.4.7",
+        "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/pelletier/go-toml@v1.2.0"
+    },
+    {
+      "ref": "pkg:golang/github.com/pingcap/errors@v0.11.4"
+    },
+    {
+      "ref": "pkg:golang/github.com/pkg/errors@v0.9.1"
+    },
+    {
+      "ref": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0"
+    },
+    {
+      "ref": "pkg:golang/github.com/russross/blackfriday@v1.5.2"
+    },
+    {
+      "ref": "pkg:golang/github.com/russross/blackfriday/v2@v2.0.1"
+    },
+    {
+      "ref": "pkg:golang/github.com/ryanuber/columnize@v2.1.0"
+    },
+    {
+      "ref": "pkg:golang/github.com/schollz/closestmatch@v2.1.0"
+    },
+    {
+      "ref": "pkg:golang/github.com/sergi/go-diff@v1.0.0"
+    },
+    {
+      "ref": "pkg:golang/github.com/shurcooL/sanitized_anchor_name@v1.0.0"
+    },
+    {
+      "ref": "pkg:golang/github.com/sirupsen/logrus@v1.7.0",
+      "dependsOn": [
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+        "pkg:golang/github.com/pmezard/go-difflib@v1.0.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/skratchdot/open-golang@v0.0.0-20200116055534-eef842397966"
+    },
+    {
+      "ref": "pkg:golang/github.com/smartystreets/assertions@v0.0.0-20180927180507-b2de0cb4f26d"
+    },
+    {
+      "ref": "pkg:golang/github.com/smartystreets/goconvey@v1.6.4",
+      "dependsOn": [
+        "pkg:golang/github.com/jtolds/gls@v4.20.0",
+        "pkg:golang/github.com/smartystreets/assertions@v0.0.0-20180927180507-b2de0cb4f26d"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/spf13/afero@v1.1.2"
+    },
+    {
+      "ref": "pkg:golang/github.com/spf13/cast@v1.3.0",
+      "dependsOn": [
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+        "pkg:golang/github.com/pmezard/go-difflib@v1.0.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/spf13/cobra@v0.0.5",
+      "dependsOn": [
+        "pkg:golang/github.com/BurntSushi/toml@v0.3.1",
+        "pkg:golang/github.com/cpuguy83/go-md2man@v1.0.10",
+        "pkg:golang/github.com/inconshreveable/mousetrap@v1.0.0",
+        "pkg:golang/github.com/mitchellh/go-homedir@v1.1.0",
+        "pkg:golang/github.com/spf13/pflag@v1.0.3",
+        "pkg:golang/github.com/spf13/viper@v1.3.2"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/spf13/jwalterweatherman@v1.0.0"
+    },
+    {
+      "ref": "pkg:golang/github.com/spf13/pflag@v1.0.3"
+    },
+    {
+      "ref": "pkg:golang/github.com/spf13/viper@v1.3.2",
+      "dependsOn": [
+        "pkg:golang/github.com/armon/consul-api@v0.0.0-20180202201655-eb2c6b5be1b6",
+        "pkg:golang/github.com/coreos/etcd@v3.3.10",
+        "pkg:golang/github.com/coreos/go-etcd@v2.0.0",
+        "pkg:golang/github.com/coreos/go-semver@v0.2.0",
+        "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7",
+        "pkg:golang/github.com/hashicorp/hcl@v1.0.0",
+        "pkg:golang/github.com/magiconair/properties@v1.8.0",
+        "pkg:golang/github.com/mitchellh/mapstructure@v1.1.2",
+        "pkg:golang/github.com/pelletier/go-toml@v1.2.0",
+        "pkg:golang/github.com/spf13/afero@v1.1.2",
+        "pkg:golang/github.com/spf13/cast@v1.3.0",
+        "pkg:golang/github.com/spf13/jwalterweatherman@v1.0.0",
+        "pkg:golang/github.com/spf13/pflag@v1.0.3",
+        "pkg:golang/github.com/xordataexchange/crypt@v0.0.3-0.20170626215501-b2862e3d0a77"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/ssor/bom@v0.0.0-20170718123548-6386211fdfcf"
+    },
+    {
+      "ref": "pkg:golang/github.com/stretchr/objx@v0.2.0",
+      "dependsOn": [
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/stretchr/testify@v1.6.1",
+      "dependsOn": [
+        "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+        "pkg:golang/gopkg.in/yaml.v3@v3.0.0-20200313102051-9f266ea9e77c"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/therecipe/qt@v0.0.0-20200701200531-7f61353ee73e",
+      "dependsOn": [
+        "pkg:golang/github.com/konsorten/go-windows-terminal-sequences@v1.0.2",
+        "pkg:golang/github.com/stretchr/objx@v0.2.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/ugorji/go@v1.1.7",
+      "dependsOn": [
+        "pkg:golang/github.com/ugorji/go/codec@v1.1.7"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/ugorji/go/codec@v1.1.7",
+      "dependsOn": [
+        "pkg:golang/github.com/ugorji/go@v1.1.7"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/urfave/cli/v2@v2.2.0",
+      "dependsOn": [
+        "pkg:golang/github.com/BurntSushi/toml@v0.3.1",
+        "pkg:golang/github.com/cpuguy83/go-md2man/v2@v2.0.0-20190314233015-f79a8a8ca69d"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/urfave/negroni@v1.0.0"
+    },
+    {
+      "ref": "pkg:golang/github.com/valyala/bytebufferpool@v1.0.0"
+    },
+    {
+      "ref": "pkg:golang/github.com/valyala/fasthttp@v1.6.0",
+      "dependsOn": [
+        "pkg:golang/github.com/klauspost/cpuid@v1.2.1",
+        "pkg:golang/github.com/valyala/bytebufferpool@v1.0.0",
+        "pkg:golang/github.com/valyala/tcplisten@v0.0.0-20161114210144-ceec8f93295a"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/valyala/fasttemplate@v1.0.1",
+      "dependsOn": [
+        "pkg:golang/github.com/valyala/bytebufferpool@v1.0.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/valyala/tcplisten@v0.0.0-20161114210144-ceec8f93295a"
+    },
+    {
+      "ref": "pkg:golang/github.com/vmihailenco/msgpack/v5@v5.1.3",
+      "dependsOn": [
+        "pkg:golang/github.com/stretchr/testify@v1.6.1",
+        "pkg:golang/github.com/vmihailenco/tagparser@v0.1.2"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/vmihailenco/tagparser@v0.1.2"
+    },
+    {
+      "ref": "pkg:golang/github.com/xeipuuv/gojsonpointer@v0.0.0-20180127040702-4e3ac2762d5f"
+    },
+    {
+      "ref": "pkg:golang/github.com/xeipuuv/gojsonreference@v0.0.0-20180127040603-bd5ef7bd5415"
+    },
+    {
+      "ref": "pkg:golang/github.com/xeipuuv/gojsonschema@v1.2.0",
+      "dependsOn": [
+        "pkg:golang/github.com/xeipuuv/gojsonpointer@v0.0.0-20180127040702-4e3ac2762d5f",
+        "pkg:golang/github.com/xeipuuv/gojsonreference@v0.0.0-20180127040603-bd5ef7bd5415"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/xordataexchange/crypt@v0.0.3-0.20170626215501-b2862e3d0a77"
+    },
+    {
+      "ref": "pkg:golang/github.com/yalp/jsonpath@v0.0.0-20180802001716-5cc68e5049a0"
+    },
+    {
+      "ref": "pkg:golang/github.com/yudai/gojsondiff@v1.0.0"
+    },
+    {
+      "ref": "pkg:golang/github.com/yudai/golcs@v0.0.0-20170316035057-ecda9a501e82"
+    },
+    {
+      "ref": "pkg:golang/github.com/yudai/pp@v2.0.1"
+    },
+    {
+      "ref": "pkg:golang/go.etcd.io/bbolt@v1.3.5"
+    },
+    {
+      "ref": "pkg:golang/github.com/ProtonMail/crypto@v0.0.0-20201112115411-41db4ea0dd1c"
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/exp@v0.0.0-20190731235908-ec7cb31e5a56",
+      "dependsOn": [
+        "pkg:golang/github.com/BurntSushi/xgb@v0.0.0-20160522181843-27f122750802"
+      ]
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/image@v0.0.0-20190802002840-cff245a6509b"
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/mobile@v0.0.0-20200801112145-973feb4309de",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/exp@v0.0.0-20190731235908-ec7cb31e5a56",
+        "pkg:golang/golang.org/x/image@v0.0.0-20190802002840-cff245a6509b",
+        "pkg:golang/golang.org/x/mod@v0.1.1-0.20191209134235-331c550502dd",
+        "pkg:golang/golang.org/x/tools@v0.0.0-20200117012304-6edc0a871e69"
+      ]
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/mod@v0.1.1-0.20191209134235-331c550502dd"
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/net@v0.0.0-20200707034311-ab3426394381",
+      "dependsOn": [
+        "pkg:golang/github.com/ProtonMail/crypto@v0.0.0-20201112115411-41db4ea0dd1c",
+        "pkg:golang/golang.org/x/sys@v0.0.0-20200323222414-85ca7c5b95cd"
+      ]
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e"
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/sys@v0.0.0-20200323222414-85ca7c5b95cd"
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/term@v0.0.0-20201117132131-f5c789dd3221"
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/text@v0.3.5-0.20201125200606-c27b9fd57aec"
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/tools@v0.0.0-20200117012304-6edc0a871e69"
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/xerrors@v0.0.0-20191204190536-9bdfabe68543"
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f"
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/fsnotify.v1@v1.4.7"
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/go-playground/assert.v1@v1.2.1"
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/go-playground/validator.v8@v8.18.2"
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/ini.v1@v1.51.1"
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/mgo.v2@v2.0.0-20180705113604-9856a29383ce"
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7"
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/yaml.v2@v2.2.8"
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.0-20200313102051-9f266ea9e77c"
+    },
+    {
+      "ref": "pkg:golang/github.com/ProtonMail/proton-bridge@v1.6.3",
+      "dependsOn": [
+        "pkg:golang/github.com/0xAX/notificator@v0.0.0-20191016112426-3962a5ea8da1",
+        "pkg:golang/github.com/Masterminds/semver/v3@v3.1.0",
+        "pkg:golang/github.com/ProtonMail/go-autostart@v0.0.0-20181114175602-c5272053443a",
+        "pkg:golang/github.com/ProtonMail/go-imap-id@v0.0.0-20190926060100-f94a56b9ecde",
+        "pkg:golang/github.com/ProtonMail/go-rfc5322@v0.5.0",
+        "pkg:golang/github.com/ProtonMail/go-vcard@v0.0.0-20180326232728-33aaa0a0c8a5",
+        "pkg:golang/github.com/ProtonMail/gopenpgp/v2@v2.1.3",
+        "pkg:golang/github.com/PuerkitoBio/goquery@v1.5.1",
+        "pkg:golang/github.com/abiosoft/ishell@v2.0.0",
+        "pkg:golang/github.com/abiosoft/readline@v0.0.0-20180607040430-155bce2042db",
+        "pkg:golang/github.com/allan-simon/go-singleinstance@v0.0.0-20160830203053-79edcfdc2dfc",
+        "pkg:golang/github.com/chzyer/logex@v1.1.10",
+        "pkg:golang/github.com/chzyer/test@v0.0.0-20180213035817-a1ea475d72b1",
+        "pkg:golang/github.com/cucumber/godog@v0.8.1",
+        "pkg:golang/github.com/ProtonMail/docker-credential-helpers@v1.1.0",
+        "pkg:golang/github.com/ProtonMail/go-imap@v0.0.0-20201228133358-4db68cea0cac",
+        "pkg:golang/github.com/emersion/go-imap-appendlimit@v0.0.0-20190308131241-25671c986a6a",
+        "pkg:golang/github.com/emersion/go-imap-idle@v0.0.0-20200601154248-f05f54664cc4",
+        "pkg:golang/github.com/emersion/go-imap-move@v0.0.0-20190710073258-6e5a51a5b342",
+        "pkg:golang/github.com/emersion/go-imap-quota@v0.0.0-20200423100218-dcfd1b7d2b41",
+        "pkg:golang/github.com/emersion/go-imap-unselect@v0.0.0-20171113212723-b985794e5f26",
+        "pkg:golang/github.com/emersion/go-mbox@v1.0.2",
+        "pkg:golang/github.com/emersion/go-message@v0.12.1-0.20201221184100-40c3f864532b",
+        "pkg:golang/github.com/emersion/go-sasl@v0.0.0-20200509203442-7bfe0ed36a21",
+        "pkg:golang/github.com/emersion/go-smtp@v0.14.0",
+        "pkg:golang/github.com/emersion/go-textwrapper@v0.0.0-20200911093747-65d896831594",
+        "pkg:golang/github.com/emersion/go-vcard@v0.0.0-20190105225839-8856043f13c5",
+        "pkg:golang/github.com/fatih/color@v1.9.0",
+        "pkg:golang/github.com/flynn-archive/go-shlex@v0.0.0-20150515145356-3f9db97f8568",
+        "pkg:golang/github.com/getsentry/sentry-go@v0.8.0",
+        "pkg:golang/github.com/go-resty/resty/v2@v2.3.0",
+        "pkg:golang/github.com/golang/mock@v1.4.4",
+        "pkg:golang/github.com/google/go-cmp@v0.5.1",
+        "pkg:golang/github.com/google/uuid@v1.1.1",
+        "pkg:golang/github.com/gopherjs/gopherjs@v0.0.0-20190430165422-3e4dfb77656c",
+        "pkg:golang/github.com/hashicorp/go-multierror@v1.1.0",
+        "pkg:golang/github.com/ProtonMail/bcrypt@v0.0.0-20170924085257-7509ea014998",
+        "pkg:golang/github.com/jaytaylor/html2text@v0.0.0-20200412013138-3577fbdbcff7",
+        "pkg:golang/github.com/keybase/go-keychain@v0.0.0-20200502122510-cda31fe0c86d",
+        "pkg:golang/github.com/logrusorgru/aurora@v2.0.3",
+        "pkg:golang/github.com/mattn/go-runewidth@v0.0.9",
+        "pkg:golang/github.com/miekg/dns@v1.1.30",
+        "pkg:golang/github.com/nsf/jsondiff@v0.0.0-20200515183724-f29ed568f4ce",
+        "pkg:golang/github.com/olekukonko/tablewriter@v0.0.4",
+        "pkg:golang/github.com/pkg/errors@v0.9.1",
+        "pkg:golang/github.com/sirupsen/logrus@v1.7.0",
+        "pkg:golang/github.com/skratchdot/open-golang@v0.0.0-20200116055534-eef842397966",
+        "pkg:golang/github.com/ssor/bom@v0.0.0-20170718123548-6386211fdfcf",
+        "pkg:golang/github.com/stretchr/testify@v1.6.1",
+        "pkg:golang/github.com/therecipe/qt@v0.0.0-20200701200531-7f61353ee73e",
+        "pkg:golang/github.com/urfave/cli/v2@v2.2.0",
+        "pkg:golang/github.com/vmihailenco/msgpack/v5@v5.1.3",
+        "pkg:golang/go.etcd.io/bbolt@v1.3.5",
+        "pkg:golang/github.com/ProtonMail/crypto@v0.0.0-20201112115411-41db4ea0dd1c",
+        "pkg:golang/golang.org/x/net@v0.0.0-20200707034311-ab3426394381",
+        "pkg:golang/golang.org/x/text@v0.3.5-0.20201125200606-c27b9fd57aec"
+      ]
+    }
+  ]
+}

--- a/proton-bridge/proton-bridge-v1.6.3.bom.xml
+++ b/proton-bridge/proton-bridge-v1.6.3.bom.xml
@@ -1,0 +1,4637 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.2" serialNumber="urn:uuid:05f17eff-5296-4a84-a16c-d572c5178b13" version="1">
+  <metadata>
+    <timestamp>2021-05-16T15:46:37+02:00</timestamp>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-gomod</name>
+        <version>v0.6.0</version>
+        <hashes>
+          <hash alg="MD5">d0517cb759962ccf9c41c8a12875a8f4</hash>
+          <hash alg="SHA-1">0a7059c2ba93d66a6f3b895ea446a74ab8cf24d0</hash>
+          <hash alg="SHA-256">d9695be77c111ebff786b384581b76ccbf4e8e4463969f6e6e22e9dd9a7ed465</hash>
+          <hash alg="SHA-512">9e6f27516614980c9a745574dcf755679efaacf5cf2beafaf1a5ad67ff99f568f811bbac65e9641f3f82c9da8066d28e5487f52f6b1fa179ec9a878e8a7d461d</hash>
+        </hashes>
+      </tool>
+    </tools>
+    <component bom-ref="pkg:golang/github.com/ProtonMail/proton-bridge@v1.6.3" type="application">
+      <name>github.com/ProtonMail/proton-bridge</name>
+      <version>v1.6.3</version>
+      <purl>pkg:golang/github.com/ProtonMail/proton-bridge@v1.6.3</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/ProtonMail/proton-bridge</url>
+        </reference>
+      </externalReferences>
+    </component>
+  </metadata>
+  <components>
+    <component bom-ref="pkg:golang/github.com/0xAX/notificator@v0.0.0-20191016112426-3962a5ea8da1" type="library">
+      <name>github.com/0xAX/notificator</name>
+      <version>v0.0.0-20191016112426-3962a5ea8da1</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">8fd1da69f6a90db3db1910e4bba7bf1d1b3a28131c287896726d7ff526f19e5e</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/0xAX/notificator@v0.0.0-20191016112426-3962a5ea8da1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/0xAX/notificator</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/AndreasBriese/bbloom@v0.0.0-20190306092124-e2d15f34fcf9" type="library">
+      <name>github.com/AndreasBriese/bbloom</name>
+      <version>v0.0.0-20190306092124-e2d15f34fcf9</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">1c3f20036b6407284c03061a1405fdc3697bbf1bc143934ca310eb921aa1b67e</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>CC0-1.0</id>
+          <name>Creative Commons Zero v1.0 Universal</name>
+          <url>https://spdx.org/licenses/CC0-1.0.html</url>
+        </license>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/AndreasBriese/bbloom@v0.0.0-20190306092124-e2d15f34fcf9</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/AndreasBriese/bbloom</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/BurntSushi/toml@v0.3.1" type="library">
+      <name>github.com/BurntSushi/toml</name>
+      <version>v0.3.1</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">597918625e98af7a817f52bbf440672f899a9343a29817c1d1751ff55976f0e4</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/BurntSushi/toml@v0.3.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/BurntSushi/toml</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/BurntSushi/xgb@v0.0.0-20160522181843-27f122750802" type="library">
+      <name>github.com/BurntSushi/xgb</name>
+      <version>v0.0.0-20160522181843-27f122750802</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d410d3cf4bbd9c2dfffe938231d347f828972556098795103423811bb8db10b7</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/BurntSushi/xgb@v0.0.0-20160522181843-27f122750802</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/BurntSushi/xgb</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/CloudyKit/fastprinter@v0.0.0-20200109182630-33d98a066a53" type="library">
+      <name>github.com/CloudyKit/fastprinter</name>
+      <version>v0.0.0-20200109182630-33d98a066a53</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b11fbff186f8b25b6d078bc3f9bf5bb551275a02f7434d0e053cd54fc07d0b47</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/CloudyKit/fastprinter@v0.0.0-20200109182630-33d98a066a53</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/CloudyKit/fastprinter</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/CloudyKit/jet/v3@v3.0.0" type="library">
+      <name>github.com/CloudyKit/jet/v3</name>
+      <version>v3.0.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d4fc0ee70e550ad954525f8a4ce06c4c66658635a47326ec19a01abb9dad3b2f</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <name>Apache License 2.0</name>
+          <url>https://spdx.org/licenses/Apache-2.0.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/CloudyKit/jet/v3@v3.0.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/CloudyKit/jet/v3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/Joker/hpp@v1.0.0" type="library">
+      <name>github.com/Joker/hpp</name>
+      <version>v1.0.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">eb9fa2b8961d457bff5f237ad82d6e12698ec77e37dab346feb2a55fa57b2a47</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/Joker/hpp@v1.0.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Joker/hpp</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/Masterminds/semver/v3@v3.1.0" type="library">
+      <name>github.com/Masterminds/semver/v3</name>
+      <version>v3.1.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6369540ec14a5514981a88cb275c8bc525dd3263184d896cd2b0afa2a98c5109</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/Masterminds/semver/v3@v3.1.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Masterminds/semver/v3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/ProtonMail/go-autostart@v0.0.0-20181114175602-c5272053443a" type="library">
+      <name>github.com/ProtonMail/go-autostart</name>
+      <version>v0.0.0-20181114175602-c5272053443a</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">7d72b62ac7e790157d361fbd48acc7721623b84f6cd2f236d091b599bb4401c7</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/ProtonMail/go-autostart@v0.0.0-20181114175602-c5272053443a</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/ProtonMail/go-autostart</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/ProtonMail/go-crypto@v0.0.0-20201208171014-cdb7591792e2" type="library">
+      <name>github.com/ProtonMail/go-crypto</name>
+      <version>v0.0.0-20201208171014-cdb7591792e2</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a509232442c76b25b9f63a7baf81b90e59a789caf931c7a30dfc2c8dcc08d525</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/ProtonMail/go-crypto@v0.0.0-20201208171014-cdb7591792e2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/ProtonMail/go-crypto</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/ProtonMail/go-imap-id@v0.0.0-20190926060100-f94a56b9ecde" type="library">
+      <name>github.com/ProtonMail/go-imap-id</name>
+      <version>v0.0.0-20190926060100-f94a56b9ecde</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">e64a10a334c310bca660ec856d0fd54ae6dec40117cc347ca8633998ef0645dc</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/ProtonMail/go-imap-id@v0.0.0-20190926060100-f94a56b9ecde</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/ProtonMail/go-imap-id</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/ProtonMail/go-mime@v0.0.0-20190923161245-9b5a4261663a" type="library">
+      <name>github.com/ProtonMail/go-mime</name>
+      <version>v0.0.0-20190923161245-9b5a4261663a</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">5ba46b80dfec4f18359acab31456fe1bcd0c166a63330eb5214fac966fb0967e</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/ProtonMail/go-mime@v0.0.0-20190923161245-9b5a4261663a</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/ProtonMail/go-mime</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/ProtonMail/go-rfc5322@v0.5.0" type="library">
+      <name>github.com/ProtonMail/go-rfc5322</name>
+      <version>v0.5.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">2db2968e07efba66190abf01806c93524dc44c69052c08d0764b9252967909c1</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/ProtonMail/go-rfc5322@v0.5.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/ProtonMail/go-rfc5322</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/ProtonMail/go-vcard@v0.0.0-20180326232728-33aaa0a0c8a5" type="library">
+      <name>github.com/ProtonMail/go-vcard</name>
+      <version>v0.0.0-20180326232728-33aaa0a0c8a5</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">5206b50c714de06531b8342bd05ef5b698bc23d1ea3c8959a1d640235951e954</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/ProtonMail/go-vcard@v0.0.0-20180326232728-33aaa0a0c8a5</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/ProtonMail/go-vcard</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/ProtonMail/gopenpgp/v2@v2.1.3" type="library">
+      <name>github.com/ProtonMail/gopenpgp/v2</name>
+      <version>v2.1.3</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">e3e9c50c9f56b5c5104e2a7f8ded8b9773f6d57840525e1ab16b1a7cbaf0f7b7</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/ProtonMail/gopenpgp/v2@v2.1.3</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/ProtonMail/gopenpgp/v2</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/PuerkitoBio/goquery@v1.5.1" type="library">
+      <name>github.com/PuerkitoBio/goquery</name>
+      <version>v1.5.1</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">3d23c11a77bc348516c3effbbc5055fa41b627fe4c3a36f373bd79e0e68a0921</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/PuerkitoBio/goquery@v1.5.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/PuerkitoBio/goquery</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/Shopify/goreferrer@v0.0.0-20181106222321-ec9c9a553398" type="library">
+      <name>github.com/Shopify/goreferrer</name>
+      <version>v0.0.0-20181106222321-ec9c9a553398</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">5830bac92a49cdbc4658587868cc45142dbcc301a9e6912ea13b6f038abfa90e</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/Shopify/goreferrer@v0.0.0-20181106222321-ec9c9a553398</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/Shopify/goreferrer</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/abiosoft/ishell@v2.0.0" type="library">
+      <name>github.com/abiosoft/ishell</name>
+      <version>v2.0.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">8d07f1eba8739e5600b70cc656d8505a7d052643c1f03240f3d56c500f47b876</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/abiosoft/ishell@v2.0.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/abiosoft/ishell</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/abiosoft/readline@v0.0.0-20180607040430-155bce2042db" type="library">
+      <name>github.com/abiosoft/readline</name>
+      <version>v0.0.0-20180607040430-155bce2042db</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0a33d44973a2629b4b6d376bd5171eb9981214343b535e484c44541ab50e471f</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/abiosoft/readline@v0.0.0-20180607040430-155bce2042db</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/abiosoft/readline</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/ajg/form@v1.5.1" type="library">
+      <name>github.com/ajg/form</name>
+      <version>v1.5.1</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b7d73bbfc2542aefd7c4e181534ca336968c968c4610985492a151ab489b19e5</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/ajg/form@v1.5.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/ajg/form</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/allan-simon/go-singleinstance@v0.0.0-20160830203053-79edcfdc2dfc" type="library">
+      <name>github.com/allan-simon/go-singleinstance</name>
+      <version>v0.0.0-20160830203053-79edcfdc2dfc</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">99971ad3f1d9fd75973fdb7191f765d861fa994cc1a80972273deee4b83c7ee0</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/allan-simon/go-singleinstance@v0.0.0-20160830203053-79edcfdc2dfc</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/allan-simon/go-singleinstance</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/andybalholm/cascadia@v1.1.0" type="library">
+      <name>github.com/andybalholm/cascadia</name>
+      <version>v1.1.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">06eb8eeac49f40d151bb52e9a606c3db91ebdaf2d85b6e49bf11ece73cec2d3a</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>BSD-2-Clause</id>
+          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/andybalholm/cascadia@v1.1.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/andybalholm/cascadia</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/antlr/antlr4@v0.0.0-20201029161626-9a95f0cc3d7c" type="library">
+      <name>github.com/antlr/antlr4</name>
+      <version>v0.0.0-20201029161626-9a95f0cc3d7c</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">8ff0b69313dfc84d1df3bfe08008c8b0257909d92a9a36fe3b45bc5bed49f886</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/antlr/antlr4@v0.0.0-20201029161626-9a95f0cc3d7c</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/antlr/antlr4</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/armon/consul-api@v0.0.0-20180202201655-eb2c6b5be1b6" type="library">
+      <name>github.com/armon/consul-api</name>
+      <version>v0.0.0-20180202201655-eb2c6b5be1b6</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">1b56cfbdc8b037217b21498a5cdb7d024de6eaef43135ac5f919ad22406955d0</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MPL-2.0</id>
+          <name>Mozilla Public License 2.0</name>
+          <url>https://spdx.org/licenses/MPL-2.0.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/armon/consul-api@v0.0.0-20180202201655-eb2c6b5be1b6</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/armon/consul-api</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/aymerick/raymond@v2.0.3-0.20180322193309-b565731e1464" type="library">
+      <name>github.com/aymerick/raymond</name>
+      <version>v2.0.3-0.20180322193309-b565731e1464</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">901a7783930a0426984323b3db44d35643a9cadacc01a92f2fb43fcf530b35cf</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/aymerick/raymond@v2.0.3-0.20180322193309-b565731e1464</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/aymerick/raymond</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/chzyer/logex@v1.1.10" type="library">
+      <name>github.com/chzyer/logex</name>
+      <version>v1.1.10</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">4b0a5ad4ae90bd0ce7c0945c7d37d02664c4ef60ea49c01ae3413e7db1c45c41</hash>
+      </hashes>
+      <purl>pkg:golang/github.com/chzyer/logex@v1.1.10</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/chzyer/logex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/chzyer/test@v0.0.0-20180213035817-a1ea475d72b1" type="library">
+      <name>github.com/chzyer/test</name>
+      <version>v0.0.0-20180213035817-a1ea475d72b1</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">abbeb7a9ff61b8dd7590341abd6b2865724d5b7c44138249c876b9436e7fb1df</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/chzyer/test@v0.0.0-20180213035817-a1ea475d72b1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/chzyer/test</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/codegangsta/inject@v0.0.0-20150114235600-33e0aa1cb7c0" type="library">
+      <name>github.com/codegangsta/inject</name>
+      <version>v0.0.0-20150114235600-33e0aa1cb7c0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b033269beabfdfe06e91d229c703b7eb9bff45bb29a7636de579ed810457abc4</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/codegangsta/inject@v0.0.0-20150114235600-33e0aa1cb7c0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/codegangsta/inject</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/coreos/etcd@v3.3.10" type="library">
+      <name>github.com/coreos/etcd</name>
+      <version>v3.3.10</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a1d778f324614e5305c1bc3b560cea519671ae74a7f543baf8f691436c8a04d6</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <name>Apache License 2.0</name>
+          <url>https://spdx.org/licenses/Apache-2.0.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/coreos/etcd@v3.3.10</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/coreos/etcd</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/coreos/go-etcd@v2.0.0" type="library">
+      <name>github.com/coreos/go-etcd</name>
+      <version>v2.0.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">59a79e10ff2bd1332fc3a102b612acc787b325fc00354abbba215db513c291c5</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <name>Apache License 2.0</name>
+          <url>https://spdx.org/licenses/Apache-2.0.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/coreos/go-etcd@v2.0.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/coreos/go-etcd</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/coreos/go-semver@v0.2.0" type="library">
+      <name>github.com/coreos/go-semver</name>
+      <version>v0.2.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">dc99b7b4b9ac80061c8c2fb8529ee126b1413ebfa7eeb02a61e4b0fd265acee6</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <name>Apache License 2.0</name>
+          <url>https://spdx.org/licenses/Apache-2.0.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/coreos/go-semver@v0.2.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/coreos/go-semver</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/cpuguy83/go-md2man@v1.0.10" type="library">
+      <name>github.com/cpuguy83/go-md2man</name>
+      <version>v1.0.10</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">05228c3656310ef9ee9e54f29aab6038d8cd9da455d6c4e9728bf0c23176da39</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/cpuguy83/go-md2man@v1.0.10</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/cpuguy83/go-md2man</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/cpuguy83/go-md2man/v2@v2.0.0-20190314233015-f79a8a8ca69d" type="library">
+      <name>github.com/cpuguy83/go-md2man/v2</name>
+      <version>v2.0.0-20190314233015-f79a8a8ca69d</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">53eb3dd144d2620a6d64cc10876691af72ee6b32c921af8f83729cd729526156</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/cpuguy83/go-md2man/v2@v2.0.0-20190314233015-f79a8a8ca69d</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/cpuguy83/go-md2man/v2</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/creack/pty@v1.1.9" type="library">
+      <name>github.com/creack/pty</name>
+      <version>v1.1.9</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b8399a1b371d8e11788bfa65823984b2b887d75634a3b44a6a911ffcb0da337c</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/creack/pty@v1.1.9</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/creack/pty</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/cucumber/godog@v0.8.1" type="library">
+      <name>github.com/cucumber/godog</name>
+      <version>v0.8.1</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9556fe5f8d48e180eb784fa26d9e746dd5e6c92c6046f898160298e80c385c4f</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/cucumber/godog@v0.8.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/cucumber/godog</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/danieljoos/wincred@v1.1.0" type="library">
+      <name>github.com/danieljoos/wincred</name>
+      <version>v1.1.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">dd135c129060e088480a165d15149d950b754230a9d6c3003c8ace9e6ed87fc8</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/danieljoos/wincred@v1.1.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/danieljoos/wincred</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/davecgh/go-spew@v1.1.1" type="library">
+      <name>github.com/davecgh/go-spew</name>
+      <version>v1.1.1</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">be3f63feed5baa7bc211f24ec1486d94e011aacdfeae41d8635de36164d4f7b7</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>ISC</id>
+          <name>ISC License</name>
+          <url>https://spdx.org/licenses/ISC.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/davecgh/go-spew@v1.1.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/davecgh/go-spew</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/dgraph-io/badger@v1.6.0" type="library">
+      <name>github.com/dgraph-io/badger</name>
+      <version>v1.6.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0ec8711716565d470ed315f8efa5490b4ed7b2be990815511ca67ddce87b12fa</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <name>Apache License 2.0</name>
+          <url>https://spdx.org/licenses/Apache-2.0.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/dgraph-io/badger@v1.6.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/dgraph-io/badger</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/dgrijalva/jwt-go@v3.2.0" type="library">
+      <name>github.com/dgrijalva/jwt-go</name>
+      <version>v3.2.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d2b9d7df363078b7430fbcdb250dd4d9ee4e0d47558a64736ba797e38e8829dc</hash>
+      </hashes>
+      <purl>pkg:golang/github.com/dgrijalva/jwt-go@v3.2.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/dgrijalva/jwt-go</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/dgryski/go-farm@v0.0.0-20190423205320-6a90982ecee2" type="library">
+      <name>github.com/dgryski/go-farm</name>
+      <version>v0.0.0-20190423205320-6a90982ecee2</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b5d9590a967f3fd0e17330934a2c6020a9b03efebec0fe431a3a8b630e525220</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/dgryski/go-farm@v0.0.0-20190423205320-6a90982ecee2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/dgryski/go-farm</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/ProtonMail/docker-credential-helpers@v1.1.0" type="library">
+      <name>github.com/ProtonMail/docker-credential-helpers</name>
+      <version>v1.1.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">fa4bd4229c1671bb4fdd616fe6c4af9059ff5cbcd2a8f381e4002d86e93dc4f9</hash>
+      </hashes>
+      <purl>pkg:golang/github.com/ProtonMail/docker-credential-helpers@v1.1.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/ProtonMail/docker-credential-helpers</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/dustin/go-humanize@v1.0.0" type="library">
+      <name>github.com/dustin/go-humanize</name>
+      <version>v1.0.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">5529d3b180a79451da336fe280ed61e97dc703bd637286d0bb17a6824ab8cd8a</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/dustin/go-humanize@v1.0.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/dustin/go-humanize</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/eknkc/amber@v0.0.0-20171010120322-cdade1c07385" type="library">
+      <name>github.com/eknkc/amber</name>
+      <version>v0.0.0-20171010120322-cdade1c07385</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">7250b59570697b69138f654775a22ef5a8d941ee2470463d8f436c9c30c1677a</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/eknkc/amber@v0.0.0-20171010120322-cdade1c07385</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/eknkc/amber</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/ProtonMail/go-imap@v0.0.0-20201228133358-4db68cea0cac" type="library">
+      <name>github.com/ProtonMail/go-imap</name>
+      <version>v0.0.0-20201228133358-4db68cea0cac</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">db1537427700892fd6dd495665391b34a5b95a42f393a1209754f4c57fac6e3b</hash>
+      </hashes>
+      <purl>pkg:golang/github.com/ProtonMail/go-imap@v0.0.0-20201228133358-4db68cea0cac</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/ProtonMail/go-imap</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/emersion/go-imap-appendlimit@v0.0.0-20190308131241-25671c986a6a" type="library">
+      <name>github.com/emersion/go-imap-appendlimit</name>
+      <version>v0.0.0-20190308131241-25671c986a6a</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">6cc7523e6eacb2cb8e16921abdebb75c60228cc4b74ead92dc4a8566667189d7</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/emersion/go-imap-appendlimit@v0.0.0-20190308131241-25671c986a6a</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/emersion/go-imap-appendlimit</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/emersion/go-imap-idle@v0.0.0-20200601154248-f05f54664cc4" type="library">
+      <name>github.com/emersion/go-imap-idle</name>
+      <version>v0.0.0-20200601154248-f05f54664cc4</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">fc92002f398276e7f9a3c4d625288e0734dbf7e47448287012552b24b969da9a</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/emersion/go-imap-idle@v0.0.0-20200601154248-f05f54664cc4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/emersion/go-imap-idle</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/emersion/go-imap-move@v0.0.0-20190710073258-6e5a51a5b342" type="library">
+      <name>github.com/emersion/go-imap-move</name>
+      <version>v0.0.0-20190710073258-6e5a51a5b342</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">e69d6ddded4fa266202d6c04c21c0453991507073201c56b3a97b1bfc01e671d</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/emersion/go-imap-move@v0.0.0-20190710073258-6e5a51a5b342</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/emersion/go-imap-move</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/emersion/go-imap-quota@v0.0.0-20200423100218-dcfd1b7d2b41" type="library">
+      <name>github.com/emersion/go-imap-quota</name>
+      <version>v0.0.0-20200423100218-dcfd1b7d2b41</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cf99431a749445ab8110374d2e3de8d3e1e881560a40219e63702797fc7245f5</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/emersion/go-imap-quota@v0.0.0-20200423100218-dcfd1b7d2b41</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/emersion/go-imap-quota</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/emersion/go-imap-unselect@v0.0.0-20171113212723-b985794e5f26" type="library">
+      <name>github.com/emersion/go-imap-unselect</name>
+      <version>v0.0.0-20171113212723-b985794e5f26</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">16249bf3e5c14104a4717dee6ebfb5b40b6544905868599166a380c1e67d5b2f</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/emersion/go-imap-unselect@v0.0.0-20171113212723-b985794e5f26</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/emersion/go-imap-unselect</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/emersion/go-mbox@v1.0.2" type="library">
+      <name>github.com/emersion/go-mbox</name>
+      <version>v1.0.2</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b44feb4fe944ba02bdcb49b21329820879f0959374e219573eb6ca9314410392</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/emersion/go-mbox@v1.0.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/emersion/go-mbox</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/emersion/go-message@v0.12.1-0.20201221184100-40c3f864532b" type="library">
+      <name>github.com/emersion/go-message</name>
+      <version>v0.12.1-0.20201221184100-40c3f864532b</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c58ba15ba7a04da08ffb38db51c7e8cbf0ebdc049d54f47d5bb7e6907bd91cf1</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/emersion/go-message@v0.12.1-0.20201221184100-40c3f864532b</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/emersion/go-message</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/emersion/go-sasl@v0.0.0-20200509203442-7bfe0ed36a21" type="library">
+      <name>github.com/emersion/go-sasl</name>
+      <version>v0.0.0-20200509203442-7bfe0ed36a21</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">389c9418c253cc74ddd57429f7c4136877ab9f1318cd168e6ac462afd8549454</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/emersion/go-sasl@v0.0.0-20200509203442-7bfe0ed36a21</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/emersion/go-sasl</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/emersion/go-smtp@v0.14.0" type="library">
+      <name>github.com/emersion/go-smtp</name>
+      <version>v0.14.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">4585b6d37a7e11c3e32fc67f6694fd959ea239cf0c1b5310cc4c7550a1245e50</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/emersion/go-smtp@v0.14.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/emersion/go-smtp</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/emersion/go-textwrapper@v0.0.0-20200911093747-65d896831594" type="library">
+      <name>github.com/emersion/go-textwrapper</name>
+      <version>v0.0.0-20200911093747-65d896831594</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">21b141b70a13432c347c8339c6fd4717e63edd98a30d1f37f5632e960c427146</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/emersion/go-textwrapper@v0.0.0-20200911093747-65d896831594</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/emersion/go-textwrapper</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/emersion/go-vcard@v0.0.0-20190105225839-8856043f13c5" type="library">
+      <name>github.com/emersion/go-vcard</name>
+      <version>v0.0.0-20190105225839-8856043f13c5</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9fdab1f7cc624b9578c76588a4f0b6aebf6650ce6b8bdaff62108429b8421eba</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/emersion/go-vcard@v0.0.0-20190105225839-8856043f13c5</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/emersion/go-vcard</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/etcd-io/bbolt@v1.3.3" type="library">
+      <name>github.com/etcd-io/bbolt</name>
+      <version>v1.3.3</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">812266c6bb37ecb813a91fe8c89056a24ea4e92bd71147ab1536e5b488579013</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/etcd-io/bbolt@v1.3.3</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/etcd-io/bbolt</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/fasthttp-contrib/websocket@v0.0.0-20160511215533-1f3b11f56072" type="library">
+      <name>github.com/fasthttp-contrib/websocket</name>
+      <version>v0.0.0-20160511215533-1f3b11f56072</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0dd76a01a583a72c32b5c1bcc3faa8439b0037c5f5d9ddd9de4a01d02dd1c6c7</hash>
+      </hashes>
+      <purl>pkg:golang/github.com/fasthttp-contrib/websocket@v0.0.0-20160511215533-1f3b11f56072</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/fasthttp-contrib/websocket</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/fatih/color@v1.9.0" type="library">
+      <name>github.com/fatih/color</name>
+      <version>v1.9.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f313c7978fead55caa1883e27f517ed55dd8de54a6aead3511a6d45b70a85b9b</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/fatih/color@v1.9.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/fatih/color</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/fatih/structs@v1.1.0" type="library">
+      <name>github.com/fatih/structs</name>
+      <version>v1.1.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">43b8ee0ccd10b5c9e10a97b22c640aca0e13388821b8d5eb90bdf6a47014331a</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/fatih/structs@v1.1.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/fatih/structs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/flynn-archive/go-shlex@v0.0.0-20150515145356-3f9db97f8568" type="library">
+      <name>github.com/flynn-archive/go-shlex</name>
+      <version>v0.0.0-20150515145356-3f9db97f8568</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">04c5d86115932ce24a961fa5381b7a9d44205c07c1ee854842de5c36b7aa48b2</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <name>Apache License 2.0</name>
+          <url>https://spdx.org/licenses/Apache-2.0.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/flynn-archive/go-shlex@v0.0.0-20150515145356-3f9db97f8568</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/flynn-archive/go-shlex</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/fsnotify/fsnotify@v1.4.7" type="library">
+      <name>github.com/fsnotify/fsnotify</name>
+      <version>v1.4.7</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">217b3e40b9a75d6d82717b98fbc333bff7d612c3c65b1a9e7cfb423f90a757d2</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/fsnotify/fsnotify@v1.4.7</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/fsnotify/fsnotify</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/gavv/httpexpect@v2.0.0" type="library">
+      <name>github.com/gavv/httpexpect</name>
+      <version>v2.0.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d5a4f508239e746148054abbe0bc6698ac1c20fe4b3a3573988749e29b213db8</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/gavv/httpexpect@v2.0.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/gavv/httpexpect</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/getsentry/sentry-go@v0.8.0" type="library">
+      <name>github.com/getsentry/sentry-go</name>
+      <version>v0.8.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">179d9c8c154bba24df756ea9e0916ec65b77a4e8ca7d6613fda91aedc749eefd</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>BSD-2-Clause</id>
+          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/getsentry/sentry-go@v0.8.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/getsentry/sentry-go</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/gin-contrib/sse@v0.0.0-20190301062529-5545eab6dad3" type="library">
+      <name>github.com/gin-contrib/sse</name>
+      <version>v0.0.0-20190301062529-5545eab6dad3</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b7c155930df72fec2295fd90896930d1457beea469707fc91cf286a4a6b613c8</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/gin-contrib/sse@v0.0.0-20190301062529-5545eab6dad3</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/gin-contrib/sse</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/gin-gonic/gin@v1.4.0" type="library">
+      <name>github.com/gin-gonic/gin</name>
+      <version>v1.4.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ded3280827ccee9a6ab11d29b73ff08b58a6a4da53efff7042d319f25af59824</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/gin-gonic/gin@v1.4.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/gin-gonic/gin</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/go-check/check@v0.0.0-20180628173108-788fd7840127" type="library">
+      <name>github.com/go-check/check</name>
+      <version>v0.0.0-20180628173108-788fd7840127</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d2090fea6cda32a926a5c25808538b90807023bc451311b4ddb6e43a40af50f2</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>BSD-2-Clause</id>
+          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/go-check/check@v0.0.0-20180628173108-788fd7840127</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/go-check/check</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/go-errors/errors@v1.0.1" type="library">
+      <name>github.com/go-errors/errors</name>
+      <version>v1.0.1</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">2d41f39a42b7194294acbff581f054c401f371ebf76a94257b35fff8eee66bac</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/go-errors/errors@v1.0.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/go-errors/errors</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/go-martini/martini@v0.0.0-20170121215854-22fa46961aab" type="library">
+      <name>github.com/go-martini/martini</name>
+      <version>v0.0.0-20170121215854-22fa46961aab</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c6f78a5b3da26ae79e4da52075eb737a5f94edec728a00d806bcb255f57fad99</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/go-martini/martini@v0.0.0-20170121215854-22fa46961aab</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/go-martini/martini</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/go-resty/resty/v2@v2.3.0" type="library">
+      <name>github.com/go-resty/resty/v2</name>
+      <version>v2.3.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">24e39e02f8d295aa534fdda9f31892d7d6717afd677868a4a07b1725e3aaf12a</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/go-resty/resty/v2@v2.3.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/go-resty/resty/v2</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/gobwas/httphead@v0.0.0-20180130184737-2c6c146eadee" type="library">
+      <name>github.com/gobwas/httphead</name>
+      <version>v0.0.0-20180130184737-2c6c146eadee</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b3edb528daa5a5e3df91a87623e8301c5f319895918e8a18fb9db8f24ea6e00d</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/gobwas/httphead@v0.0.0-20180130184737-2c6c146eadee</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/gobwas/httphead</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/gobwas/pool@v0.2.0" type="library">
+      <name>github.com/gobwas/pool</name>
+      <version>v0.2.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">4049943a59d28d6b67a5118717749ab8488eb32f360aea7cdd57f62dc3259dcf</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/gobwas/pool@v0.2.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/gobwas/pool</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/gobwas/ws@v1.0.2" type="library">
+      <name>github.com/gobwas/ws</name>
+      <version>v1.0.2</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0a801abd6ff077f92e95f66648806dea9db89f88fbb4780d5428ec7c754d51ba</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/gobwas/ws@v1.0.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/gobwas/ws</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/golang/mock@v1.4.4" type="library">
+      <name>github.com/golang/mock</name>
+      <version>v1.4.4</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">97be425c6452c1b69836997f6765f55c82003120aabaf5e0a5564387010826c7</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <name>Apache License 2.0</name>
+          <url>https://spdx.org/licenses/Apache-2.0.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/golang/mock@v1.4.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/golang/mock</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/golang/protobuf@v1.3.1" type="library">
+      <name>github.com/golang/protobuf</name>
+      <version>v1.3.1</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">605f3e7e50574b978ef36e93e27cea3ebc5f8504e18579746337ee50fbb84818</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/golang/protobuf@v1.3.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/golang/protobuf</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/gomodule/redigo@v1.7.1-0.20190724094224-574c33c3df38" type="library">
+      <name>github.com/gomodule/redigo</name>
+      <version>v1.7.1-0.20190724094224-574c33c3df38</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cb45a686f9a5edc1a7ccf6bd9e8727fdf32b68c1ff94c0dd786fab931e158186</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <name>Apache License 2.0</name>
+          <url>https://spdx.org/licenses/Apache-2.0.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/gomodule/redigo@v1.7.1-0.20190724094224-574c33c3df38</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/gomodule/redigo</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/google/go-cmp@v0.5.1" type="library">
+      <name>github.com/google/go-cmp</name>
+      <version>v0.5.1</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">245ac51016f6c4ab9f83a5e426c26bf966ca6f8150954462e5151c06f798bbd9</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/google/go-cmp@v0.5.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/google/go-cmp</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/google/go-querystring@v1.0.0" type="library">
+      <name>github.com/google/go-querystring</name>
+      <version>v1.0.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">5e4c22fdad6b72f360d4f3d87b9bc8f066de058fe3ad5b835f9012b803564eb9</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/google/go-querystring@v1.0.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/google/go-querystring</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/google/gofuzz@v1.0.0" type="library">
+      <name>github.com/google/gofuzz</name>
+      <version>v1.0.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">03c3de5b9f69c44f48a0546a069dfb53e99235a428678e85d5fd1ff3add7497c</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <name>Apache License 2.0</name>
+          <url>https://spdx.org/licenses/Apache-2.0.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/google/gofuzz@v1.0.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/google/gofuzz</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/google/uuid@v1.1.1" type="library">
+      <name>github.com/google/uuid</name>
+      <version>v1.1.1</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">1a46dcb21fc66e95f3ee53dfb4b0373fa4d83308c22d89bcde388541917fde06</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/google/uuid@v1.1.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/google/uuid</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/gopherjs/gopherjs@v0.0.0-20190430165422-3e4dfb77656c" type="library">
+      <name>github.com/gopherjs/gopherjs</name>
+      <version>v0.0.0-20190430165422-3e4dfb77656c</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ee517e573d0baa2462767cc2d4eabce9fa57d6afe212fd8a25dac2b6db588d3e</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>BSD-2-Clause</id>
+          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/gopherjs/gopherjs@v0.0.0-20190430165422-3e4dfb77656c</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/gopherjs/gopherjs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/gorilla/websocket@v1.4.1" type="library">
+      <name>github.com/gorilla/websocket</name>
+      <version>v1.4.1</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">abb01e0c1a67064f00a20703e0349a83f524c3f295f988732e3d9b3f91ef2823</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>BSD-2-Clause</id>
+          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/gorilla/websocket@v1.4.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/gorilla/websocket</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/hashicorp/errwrap@v1.0.0" type="library">
+      <name>github.com/hashicorp/errwrap</name>
+      <version>v1.0.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">84baeab440e74727b7fac831eb3e2a54b36ebe21f7311e5a434ca43496bf5180</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MPL-2.0</id>
+          <name>Mozilla Public License 2.0</name>
+          <url>https://spdx.org/licenses/MPL-2.0.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/hashicorp/errwrap@v1.0.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/hashicorp/errwrap</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/hashicorp/go-multierror@v1.1.0" type="library">
+      <name>github.com/hashicorp/go-multierror</name>
+      <version>v1.1.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">07d533c064097a19d4635c8dae7c111077377c66c2db179fa3c8384db12569c2</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MPL-2.0</id>
+          <name>Mozilla Public License 2.0</name>
+          <url>https://spdx.org/licenses/MPL-2.0.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/hashicorp/go-multierror@v1.1.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/hashicorp/go-multierror</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/hashicorp/go-version@v1.2.0" type="library">
+      <name>github.com/hashicorp/go-version</name>
+      <version>v1.2.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">def35efdf585e4206044882e75ad6679686c647cb79bc802279c31f9d2335ff1</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MPL-2.0</id>
+          <name>Mozilla Public License 2.0</name>
+          <url>https://spdx.org/licenses/MPL-2.0.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/hashicorp/go-version@v1.2.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/hashicorp/go-version</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/hashicorp/hcl@v1.0.0" type="library">
+      <name>github.com/hashicorp/hcl</name>
+      <version>v1.0.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d009e5ce3a62e2f11ab1378d167da62c98134b0b74fbab1fb224c6f2a7161b1e</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MPL-2.0</id>
+          <name>Mozilla Public License 2.0</name>
+          <url>https://spdx.org/licenses/MPL-2.0.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/hashicorp/hcl@v1.0.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/hashicorp/hcl</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/hpcloud/tail@v1.0.0" type="library">
+      <name>github.com/hpcloud/tail</name>
+      <version>v1.0.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9df08ebca61f92060ff21922ae12687174f6fb3383f3250d8d76967d397214a2</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/hpcloud/tail@v1.0.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/hpcloud/tail</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/imkira/go-interpol@v1.1.0" type="library">
+      <name>github.com/imkira/go-interpol</name>
+      <version>v1.1.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">28888aaf45521b60945b5865d63a62caecee25e2945290bc88cd40204ecdd559</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/imkira/go-interpol@v1.1.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/imkira/go-interpol</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/inconshreveable/mousetrap@v1.0.0" type="library">
+      <name>github.com/inconshreveable/mousetrap</name>
+      <version>v1.0.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">67cb6ee6cada2d709721c011c41a7ff1c6ef97055aed9d4d1e0f5710a86d4af3</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <name>Apache License 2.0</name>
+          <url>https://spdx.org/licenses/Apache-2.0.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/inconshreveable/mousetrap@v1.0.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/inconshreveable/mousetrap</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/iris-contrib/blackfriday@v2.0.0" type="library">
+      <name>github.com/iris-contrib/blackfriday</name>
+      <version>v2.0.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c5559ad5703151c00b9cbdf6a4f9ddf9523f0237c1fe0be6e7ba85a99b401409</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>BSD-2-Clause</id>
+          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/iris-contrib/blackfriday@v2.0.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/iris-contrib/blackfriday</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/iris-contrib/go.uuid@v2.0.0" type="library">
+      <name>github.com/iris-contrib/go.uuid</name>
+      <version>v2.0.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9db9571d236874d6904bc950503b1018e05b5e904a360fc8e7e299ed6de635d1</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/iris-contrib/go.uuid@v2.0.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/iris-contrib/go.uuid</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/iris-contrib/jade@v1.1.3" type="library">
+      <name>github.com/iris-contrib/jade</name>
+      <version>v1.1.3</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a7b27fe74234723a34c2afd559508315df2d68f25bb850be6eadb74a7891157d</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/iris-contrib/jade@v1.1.3</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/iris-contrib/jade</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/iris-contrib/pongo2@v0.0.1" type="library">
+      <name>github.com/iris-contrib/pongo2</name>
+      <version>v0.0.1</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cc63fba56e75a22e5e41930894603723e14763dfc739058307ee7bdb28a7d2da</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/iris-contrib/pongo2@v0.0.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/iris-contrib/pongo2</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/iris-contrib/schema@v0.0.1" type="library">
+      <name>github.com/iris-contrib/schema</name>
+      <version>v0.0.1</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d7483f5a7a1147e53e5d71d62811de372ffeb5998cda47005462ceb33fb26830</hash>
+      </hashes>
+      <purl>pkg:golang/github.com/iris-contrib/schema@v0.0.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/iris-contrib/schema</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/ProtonMail/bcrypt@v0.0.0-20170924085257-7509ea014998" type="library">
+      <name>github.com/ProtonMail/bcrypt</name>
+      <version>v0.0.0-20170924085257-7509ea014998</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">613dae57042245067109a69a8707dc813ab68f78faeb0d349ffdbb81bff3b9bb</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/ProtonMail/bcrypt@v0.0.0-20170924085257-7509ea014998</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/ProtonMail/bcrypt</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/jaytaylor/html2text@v0.0.0-20200412013138-3577fbdbcff7" type="library">
+      <name>github.com/jaytaylor/html2text</name>
+      <version>v0.0.0-20200412013138-3577fbdbcff7</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">8347c01818ac1da110d1346ad6206f7a61517fef0011612604449289607756c7</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/jaytaylor/html2text@v0.0.0-20200412013138-3577fbdbcff7</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/jaytaylor/html2text</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/json-iterator/go@v1.1.9" type="library">
+      <name>github.com/json-iterator/go</name>
+      <version>v1.1.9</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f72cee77f1eddfaca0c1ab46c79e95c0266d948ff6003d794f55f6b234ae1a7b</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/json-iterator/go@v1.1.9</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/json-iterator/go</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/jtolds/gls@v4.20.0" type="library">
+      <name>github.com/jtolds/gls</name>
+      <version>v4.20.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0d61bff8c2de500d8311984d8f3cce613ec6aa4e2b4ecc63d11948dd914bf59f</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/jtolds/gls@v4.20.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/jtolds/gls</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/k0kubun/colorstring@v0.0.0-20150214042306-9440f1994b88" type="library">
+      <name>github.com/k0kubun/colorstring</name>
+      <version>v0.0.0-20150214042306-9440f1994b88</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b82d507d29489e9405f8cd1aa3ae629a1c2a2a7cf7436cff77c3d6651310bc33</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/k0kubun/colorstring@v0.0.0-20150214042306-9440f1994b88</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/k0kubun/colorstring</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/kataras/golog@v0.0.10" type="library">
+      <name>github.com/kataras/golog</name>
+      <version>v0.0.10</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">bd10d1526c1a71ca3fa660409bc81e2e7f2b1c475cfbd678340af94a1ed31bfe</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/kataras/golog@v0.0.10</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/kataras/golog</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/kataras/iris/v12@v12.1.8" type="library">
+      <name>github.com/kataras/iris/v12</name>
+      <version>v12.1.8</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">3b78096ac8e6ed9c69c704c7f2d02966cbdfdbbe2c712190014a4d7b8edcdfb5</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/kataras/iris/v12@v12.1.8</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/kataras/iris/v12</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/kataras/neffos@v0.0.14" type="library">
+      <name>github.com/kataras/neffos</name>
+      <version>v0.0.14</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a5d25a4ef506dcd41f78c6db54223c253d93e60a0f95dcb27d40763c97e1d41b</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/kataras/neffos@v0.0.14</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/kataras/neffos</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/kataras/pio@v0.0.2" type="library">
+      <name>github.com/kataras/pio</name>
+      <version>v0.0.2</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">e8d022fae3c9fd9ba277a9ab00a960a5b235d7fccafe5578076af159a24df7c6</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/kataras/pio@v0.0.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/kataras/pio</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/kataras/sitemap@v0.0.5" type="library">
+      <name>github.com/kataras/sitemap</name>
+      <version>v0.0.5</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">e0708e357e512e0572e86e11918395def28d7266bda76dfa2dd18e8a926c6851</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/kataras/sitemap@v0.0.5</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/kataras/sitemap</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/keybase/go-keychain@v0.0.0-20200502122510-cda31fe0c86d" type="library">
+      <name>github.com/keybase/go-keychain</name>
+      <version>v0.0.0-20200502122510-cda31fe0c86d</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">8158e10427d51a5df6448068a0e00dcdfc3ed14a97f0753ec8f94cbfcbf2a5c8</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/keybase/go-keychain@v0.0.0-20200502122510-cda31fe0c86d</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/keybase/go-keychain</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/keybase/go.dbus@v0.0.0-20200324223359-a94be52c0b03" type="library">
+      <name>github.com/keybase/go.dbus</name>
+      <version>v0.0.0-20200324223359-a94be52c0b03</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">93dac2aae702b0fa4128387d803c24dd4e3a4dc35dee3a4a6a179df491880866</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>BSD-2-Clause</id>
+          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/keybase/go.dbus@v0.0.0-20200324223359-a94be52c0b03</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/keybase/go.dbus</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/klauspost/compress@v1.9.7" type="library">
+      <name>github.com/klauspost/compress</name>
+      <version>v1.9.7</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">8585b580ff78254980841b49f8b373e4ccbe801a1b0f13d1d6256e2ae836e9a0</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/klauspost/compress@v1.9.7</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/klauspost/compress</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/klauspost/cpuid@v1.2.1" type="library">
+      <name>github.com/klauspost/cpuid</name>
+      <version>v1.2.1</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">bc98be3bf9cc745b74bea9bc359048eb0cc02d6740d97f9e822d2880dcab0bfc</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/klauspost/cpuid@v1.2.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/klauspost/cpuid</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/konsorten/go-windows-terminal-sequences@v1.0.2" type="library">
+      <name>github.com/konsorten/go-windows-terminal-sequences</name>
+      <version>v1.0.2</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">0c1d7b6a0d7d92bc7d085b33e28dde9d3acf5f22170a5fb68825c7fda300a7db</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/konsorten/go-windows-terminal-sequences@v1.0.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/konsorten/go-windows-terminal-sequences</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/kr/pretty@v0.1.0" type="library">
+      <name>github.com/kr/pretty</name>
+      <version>v0.1.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">2ff0b0374cdead90e644551aa523e2b64e9ff90dfed336b5ad093356e3223052</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/kr/pretty@v0.1.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/kr/pretty</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/kr/pty@v1.1.1" type="library">
+      <name>github.com/kr/pty</name>
+      <version>v1.1.1</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">564a1723049ba01a6793df4efca15ab801082ee347bf90d514a64c04dfe0520c</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/kr/pty@v1.1.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/kr/pty</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/kr/text@v0.2.0" type="library">
+      <name>github.com/kr/text</name>
+      <version>v0.2.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">e4dc7461ad19a98db2815dfae90cedbab1c8d7726af79029715689061a52f806</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/kr/text@v0.2.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/kr/text</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/labstack/echo/v4@v4.1.11" type="library">
+      <name>github.com/labstack/echo/v4</name>
+      <version>v4.1.11</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cf4059a00ad8e05a9da54125fb0947a78867affa1247a3139909aff0e1d2a30c</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/labstack/echo/v4@v4.1.11</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/labstack/echo/v4</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/labstack/gommon@v0.3.0" type="library">
+      <name>github.com/labstack/gommon</name>
+      <version>v0.3.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">24478ed1bbdcefc3ca7721f19684ca885f010f9886ac7f13e8c49e1af4a0a1bd</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/labstack/gommon@v0.3.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/labstack/gommon</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/logrusorgru/aurora@v2.0.3" type="library">
+      <name>github.com/logrusorgru/aurora</name>
+      <version>v2.0.3</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">2dff73b09ee12bc6bd7e6adc7f970c0337de1439857bdb82bb555526f0382c32</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>Unlicense</id>
+          <name>The Unlicense</name>
+          <url>https://spdx.org/licenses/Unlicense.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/logrusorgru/aurora@v2.0.3</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/logrusorgru/aurora</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/magiconair/properties@v1.8.0" type="library">
+      <name>github.com/magiconair/properties</name>
+      <version>v1.8.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">2cb8179ac85e5de46850e04e8edc0f40258862a33f2d4d5ac83b4378f7ab45c6</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>BSD-2-Clause</id>
+          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/magiconair/properties@v1.8.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/magiconair/properties</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/martinlindhe/base36@v1.1.0" type="library">
+      <name>github.com/martinlindhe/base36</name>
+      <version>v1.1.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">708c2fbf062c7bfd3ed429143d81f966f548606dc9ac82e640421b2ee6abd366</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/martinlindhe/base36@v1.1.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/martinlindhe/base36</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/mattn/go-colorable@v0.1.4" type="library">
+      <name>github.com/mattn/go-colorable</name>
+      <version>v0.1.4</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b276cf2c1f1f55f53d8b06dba37d133ed6cb473c16bba6894ba5e1e1e69abe20</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/mattn/go-colorable@v0.1.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/mattn/go-colorable</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/mattn/go-isatty@v0.0.11" type="library">
+      <name>github.com/mattn/go-isatty</name>
+      <version>v0.0.11</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">1713ce4c536a1a4b835068b71ffaa451b40ee198816b66eb2aae6bd25f1319e3</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/mattn/go-isatty@v0.0.11</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/mattn/go-isatty</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/mattn/go-runewidth@v0.0.9" type="library">
+      <name>github.com/mattn/go-runewidth</name>
+      <version>v0.0.9</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">2e6f7de5fdeb7f176977a4d29ae5421d56ff421ba9b97958afcb0223f41d13ed</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/mattn/go-runewidth@v0.0.9</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/mattn/go-runewidth</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/mattn/goveralls@v0.0.2" type="library">
+      <name>github.com/mattn/goveralls</name>
+      <version>v0.0.2</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ede241e84aac3e1455c6fc045c69ea74edac248d0f4ecad6a13317124f7f3907</hash>
+      </hashes>
+      <purl>pkg:golang/github.com/mattn/goveralls@v0.0.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/mattn/goveralls</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/mediocregopher/radix/v3@v3.4.2" type="library">
+      <name>github.com/mediocregopher/radix/v3</name>
+      <version>v3.4.2</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">81a95b3c18c8c26c91120c0609f4043785fc9716c99ca058bab833f957dc4ad0</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/mediocregopher/radix/v3@v3.4.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/mediocregopher/radix/v3</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/microcosm-cc/bluemonday@v1.0.2" type="library">
+      <name>github.com/microcosm-cc/bluemonday</name>
+      <version>v1.0.2</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">e653df2d34c0bc06ed4b456a4fef78c8eb459c67d4598cb1d3e893a02dceb37b</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/microcosm-cc/bluemonday@v1.0.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/microcosm-cc/bluemonday</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/miekg/dns@v1.1.30" type="library">
+      <name>github.com/miekg/dns</name>
+      <version>v1.1.30</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">430c3a16c7859fc3d17f0d3b8ee7aa217aa8766d092a288ab8ad037974aa7f2a</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/miekg/dns@v1.1.30</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/miekg/dns</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/mitchellh/go-homedir@v1.1.0" type="library">
+      <name>github.com/mitchellh/go-homedir</name>
+      <version>v1.1.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">96e905f738971710c53e4035becaf9ce97355ee3c39ffc059edab9986fb81346</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/mitchellh/go-homedir@v1.1.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/mitchellh/go-homedir</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/mitchellh/mapstructure@v1.1.2" type="library">
+      <name>github.com/mitchellh/mapstructure</name>
+      <version>v1.1.2</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">7e6358570aa749f07d99953a392d8ee86b1733ec1cb24643b8a433bcdd440de1</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/mitchellh/mapstructure@v1.1.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/mitchellh/mapstructure</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd" type="library">
+      <name>github.com/modern-go/concurrent</name>
+      <version>v0.0.0-20180306012644-bacd9c7ef1dd</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">4d12da67d703ff0f0f561f779ec3d76b556b43a8e5c0be6837c975e1095c35f8</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <name>Apache License 2.0</name>
+          <url>https://spdx.org/licenses/Apache-2.0.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/modern-go/concurrent</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/modern-go/reflect2@v1.0.1" type="library">
+      <name>github.com/modern-go/reflect2</name>
+      <version>v1.0.1</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">f5fe35dacfba4666172d665213355580f18aec2d8fa611e3e5126bbdfc7d0162</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <name>Apache License 2.0</name>
+          <url>https://spdx.org/licenses/Apache-2.0.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/modern-go/reflect2@v1.0.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/modern-go/reflect2</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/moul/http2curl@v1.0.0" type="library">
+      <name>github.com/moul/http2curl</name>
+      <version>v1.0.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">751316a00b5bf9e3f13252e4ac26c0aa1e1394f1d7be8194490df6dfff596a1b</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/moul/http2curl@v1.0.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/moul/http2curl</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/nats-io/jwt@v0.3.0" type="library">
+      <name>github.com/nats-io/jwt</name>
+      <version>v0.3.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c5d9f3c0511357efa335ce16d66c3ffea1722466f60013a899b9992504b8f90a</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <name>Apache License 2.0</name>
+          <url>https://spdx.org/licenses/Apache-2.0.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/nats-io/jwt@v0.3.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/nats-io/jwt</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/nats-io/nats.go@v1.9.1" type="library">
+      <name>github.com/nats-io/nats.go</name>
+      <version>v1.9.1</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">8a4dc76cb859d180012eda3b897f34a592cfc3fe9dc774fefbe3192702e732b4</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <name>Apache License 2.0</name>
+          <url>https://spdx.org/licenses/Apache-2.0.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/nats-io/nats.go@v1.9.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/nats-io/nats.go</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/nats-io/nkeys@v0.1.0" type="library">
+      <name>github.com/nats-io/nkeys</name>
+      <version>v0.1.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a8c778fa944781daf59c00a5bbeda1ff66b91764e629c0b38c20dacd5811a17e</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <name>Apache License 2.0</name>
+          <url>https://spdx.org/licenses/Apache-2.0.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/nats-io/nkeys@v0.1.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/nats-io/nkeys</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/nats-io/nuid@v1.0.1" type="library">
+      <name>github.com/nats-io/nuid</name>
+      <version>v1.0.1</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">e6203c0d3f15eeaf162b611272fda969d35afeb4c449cd4a7673f0e130b6a5ac</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <name>Apache License 2.0</name>
+          <url>https://spdx.org/licenses/Apache-2.0.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/nats-io/nuid@v1.0.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/nats-io/nuid</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e" type="library">
+      <name>github.com/niemeyer/pretty</name>
+      <version>v0.0.0-20200227124842-a10e7caefd8e</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">7c3e7b11147826d12ab166df3e1bf80cc880a47ca58a22b9c424cd5523e2680b</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/niemeyer/pretty</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/nsf/jsondiff@v0.0.0-20200515183724-f29ed568f4ce" type="library">
+      <name>github.com/nsf/jsondiff</name>
+      <version>v0.0.0-20200515183724-f29ed568f4ce</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">44f7257e06b648426680c9b3da4f8c83b728c19f32bf84ebab0f54b096f2ef9f</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/nsf/jsondiff@v0.0.0-20200515183724-f29ed568f4ce</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/nsf/jsondiff</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/olekukonko/tablewriter@v0.0.4" type="library">
+      <name>github.com/olekukonko/tablewriter</name>
+      <version>v0.0.4</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">bc70ff6187b55a8968efc9281b6f7d7fb57f5404b4f1ce88a422e7f848dfff0f</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/olekukonko/tablewriter@v0.0.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/olekukonko/tablewriter</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/onsi/ginkgo@v1.10.3" type="library">
+      <name>github.com/onsi/ginkgo</name>
+      <version>v1.10.3</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">3a8c5b8df5d5672a1dd5f99662123b484c9a0fc074d329cfdd3f83e468b21ce6</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/onsi/ginkgo@v1.10.3</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/onsi/ginkgo</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/onsi/gomega@v1.7.1" type="library">
+      <name>github.com/onsi/gomega</name>
+      <version>v1.7.1</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">2b48dc442c0d40cdef146875a6932d0e1ffeec0a49ae395d957f1f0348c34cb4</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/onsi/gomega@v1.7.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/onsi/gomega</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/pelletier/go-toml@v1.2.0" type="library">
+      <name>github.com/pelletier/go-toml</name>
+      <version>v1.2.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">4f9ccc18c2fad56a7e16571b5a34434fbc80c6124d0223cf2ce1440aad7cd737</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/pelletier/go-toml@v1.2.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/pelletier/go-toml</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/pingcap/errors@v0.11.4" type="library">
+      <name>github.com/pingcap/errors</name>
+      <version>v0.11.4</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">945b9057fa1a50c19c0f6b6ab7ed3544e4a626cef9546d53a043a46486789c4e</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>BSD-2-Clause</id>
+          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/pingcap/errors@v0.11.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/pingcap/errors</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/pkg/errors@v0.9.1" type="library">
+      <name>github.com/pkg/errors</name>
+      <version>v0.9.1</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">14404bc75cd2db5e28c298f2eeab017a2c5b51192e850030acae54c0b193c2de</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>BSD-2-Clause</id>
+          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/pkg/errors@v0.9.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/pkg/errors</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/pmezard/go-difflib@v1.0.0" type="library">
+      <name>github.com/pmezard/go-difflib</name>
+      <version>v1.0.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">e030700c4d0d1b24280476cb4183f04943e808c591e41133224fdfd6565b0103</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/pmezard/go-difflib@v1.0.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/pmezard/go-difflib</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/russross/blackfriday@v1.5.2" type="library">
+      <name>github.com/russross/blackfriday</name>
+      <version>v1.5.2</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">1f2bc2d0045f9d906a9d7c00045792647a4abc91c925f3f3f3518db9e2e3d28a</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>BSD-2-Clause</id>
+          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/russross/blackfriday@v1.5.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/russross/blackfriday</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/russross/blackfriday/v2@v2.0.1" type="library">
+      <name>github.com/russross/blackfriday/v2</name>
+      <version>v2.0.1</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">94fa9502d7be1ee1cd7e127fd0b0bdf04496473f1a7f2f6d33fd112bc9bda3e4</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>BSD-2-Clause</id>
+          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/russross/blackfriday/v2@v2.0.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/russross/blackfriday/v2</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/ryanuber/columnize@v2.1.0" type="library">
+      <name>github.com/ryanuber/columnize</name>
+      <version>v2.1.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">67857b6becfe4e5a74ee5af8b920af2a90025f5420b85484816ee0a21db5f62c</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/ryanuber/columnize@v2.1.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/ryanuber/columnize</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/schollz/closestmatch@v2.1.0" type="library">
+      <name>github.com/schollz/closestmatch</name>
+      <version>v2.1.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d6b425d6e1e57fc2a49546fd9d947fef0b40c2f06cbeb01a05c45164bd84556a</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/schollz/closestmatch@v2.1.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/schollz/closestmatch</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/sergi/go-diff@v1.0.0" type="library">
+      <name>github.com/sergi/go-diff</name>
+      <version>v1.0.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">2a971adea44daddb8d9ce41e6b305dd32b1a2ab509888b88487c688244fd44f4</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/sergi/go-diff@v1.0.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/sergi/go-diff</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/shurcooL/sanitized_anchor_name@v1.0.0" type="library">
+      <name>github.com/shurcooL/sanitized_anchor_name</name>
+      <version>v1.0.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">3dd9a808eeb0bdbb3eef2ac9c8c391b78fc1998e486322704bf90e896c7c987a</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/shurcooL/sanitized_anchor_name@v1.0.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/shurcooL/sanitized_anchor_name</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/sirupsen/logrus@v1.7.0" type="library">
+      <name>github.com/sirupsen/logrus</name>
+      <version>v1.7.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">4a1ac3d54f69641d764d7d1c572d03b5e3e8087f7b2bc12d5fe9a0ed901152d3</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/sirupsen/logrus@v1.7.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/sirupsen/logrus</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/skratchdot/open-golang@v0.0.0-20200116055534-eef842397966" type="library">
+      <name>github.com/skratchdot/open-golang</name>
+      <version>v0.0.0-20200116055534-eef842397966</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">24802eab71047fd7206d4e80b463cae024c6dd97fa08a30da9fd0c1d38200140</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/skratchdot/open-golang@v0.0.0-20200116055534-eef842397966</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/skratchdot/open-golang</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/smartystreets/assertions@v0.0.0-20180927180507-b2de0cb4f26d" type="library">
+      <name>github.com/smartystreets/assertions</name>
+      <version>v0.0.0-20180927180507-b2de0cb4f26d</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">cc4f7290495643afcd6261dade3a66ff21e7238c52a1f3fe50fe92a631dc49e3</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/smartystreets/assertions@v0.0.0-20180927180507-b2de0cb4f26d</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/smartystreets/assertions</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/smartystreets/goconvey@v1.6.4" type="library">
+      <name>github.com/smartystreets/goconvey</name>
+      <version>v1.6.4</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">7efd14f0550830f35fd4bf659c72ef2e182272b2150a112477320a62a6cd0bdb</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/smartystreets/goconvey@v1.6.4</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/smartystreets/goconvey</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/spf13/afero@v1.1.2" type="library">
+      <name>github.com/spf13/afero</name>
+      <version>v1.1.2</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9bcff3d6deff7f08f2b2341161b3f4443f9b50817ff2d2703dd119b08f370022</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <name>Apache License 2.0</name>
+          <url>https://spdx.org/licenses/Apache-2.0.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/spf13/afero@v1.1.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/spf13/afero</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/spf13/cast@v1.3.0" type="library">
+      <name>github.com/spf13/cast</name>
+      <version>v1.3.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a207adfff095384a057b0a90c70af4123e728f2827a8692f820484fe0077e50f</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/spf13/cast@v1.3.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/spf13/cast</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/spf13/cobra@v0.0.5" type="library">
+      <name>github.com/spf13/cobra</name>
+      <version>v0.0.5</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">7f407e2e42d7e83b66447d62b28340f554ed3542bd2bcc58776f0934d7cebffb</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <name>Apache License 2.0</name>
+          <url>https://spdx.org/licenses/Apache-2.0.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/spf13/cobra@v0.0.5</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/spf13/cobra</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/spf13/jwalterweatherman@v1.0.0" type="library">
+      <name>github.com/spf13/jwalterweatherman</name>
+      <version>v1.0.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">5c711dc81f8472f96a65a99233864e30695cf77b7a01cb0112ef46735be7ef29</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/spf13/jwalterweatherman@v1.0.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/spf13/jwalterweatherman</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/spf13/pflag@v1.0.3" type="library">
+      <name>github.com/spf13/pflag</name>
+      <version>v1.0.3</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ccf013e821b2eb05de43b36d4e76937ab7ca3ac57a57a17c6a01d71626b30e48</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/spf13/pflag@v1.0.3</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/spf13/pflag</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/spf13/viper@v1.3.2" type="library">
+      <name>github.com/spf13/viper</name>
+      <version>v1.3.2</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">55416ac3929ca917fb8bbd063b35bb37e43bfa0c55064492aa25c1d76f894383</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/spf13/viper@v1.3.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/spf13/viper</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/ssor/bom@v0.0.0-20170718123548-6386211fdfcf" type="library">
+      <name>github.com/ssor/bom</name>
+      <version>v0.0.0-20170718123548-6386211fdfcf</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a6f6d9d253345d63c1a942aa154f1c99abeca6f225f67ba5398c1dcba205451a</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/ssor/bom@v0.0.0-20170718123548-6386211fdfcf</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/ssor/bom</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/stretchr/objx@v0.2.0" type="library">
+      <name>github.com/stretchr/objx</name>
+      <version>v0.2.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">1db8363627692c4f2f7840641194cbdc2be5914215cee53d8c3a6564ee78738f</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/stretchr/objx@v0.2.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/stretchr/objx</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/stretchr/testify@v1.6.1" type="library">
+      <name>github.com/stretchr/testify</name>
+      <version>v1.6.1</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">8433ce1e6a4ea4fe3495250b72ac3b22b45bfeeef0e91a430bddfdf57ca835dd</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/stretchr/testify@v1.6.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/stretchr/testify</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/therecipe/qt@v0.0.0-20200701200531-7f61353ee73e" type="library">
+      <name>github.com/therecipe/qt</name>
+      <version>v0.0.0-20200701200531-7f61353ee73e</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">1b40d0fd3450cab1198ed2e52f07af163691886f1e782325abd59743638ed9b9</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>LGPL-3.0</id>
+          <name>GNU Lesser General Public License v3.0 only</name>
+          <url>https://spdx.org/licenses/LGPL-3.0.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/therecipe/qt@v0.0.0-20200701200531-7f61353ee73e</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/therecipe/qt</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/ugorji/go@v1.1.7" type="library">
+      <name>github.com/ugorji/go</name>
+      <version>v1.1.7</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">ffaf20cb687ed6658caf0645783d644226a5752cc06f8df676da5e278da8bdda</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/ugorji/go@v1.1.7</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/ugorji/go</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/ugorji/go/codec@v1.1.7" type="library">
+      <name>github.com/ugorji/go/codec</name>
+      <version>v1.1.7</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d92bd0695675a2e62baca2b0a12936a7377803d7af94a25bf684cbf8e68b512b</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/ugorji/go/codec@v1.1.7</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/ugorji/go/codec</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/urfave/cli/v2@v2.2.0" type="library">
+      <name>github.com/urfave/cli/v2</name>
+      <version>v2.2.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">2534e733ac0acdd03426aa1d77deba3158f8bd66dbaae67291e5f5b0a6ded82e</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/urfave/cli/v2@v2.2.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/urfave/cli/v2</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/urfave/negroni@v1.0.0" type="library">
+      <name>github.com/urfave/negroni</name>
+      <version>v1.0.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9088a63a2b68ca9ab7e0aed31bb0d4689f64abf37839fbb08b5b23cf42a2a577</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/urfave/negroni@v1.0.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/urfave/negroni</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/valyala/bytebufferpool@v1.0.0" type="library">
+      <name>github.com/valyala/bytebufferpool</name>
+      <version>v1.0.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">1aa0394c2ff4d36d58fdbf451b83a2f4caf7abb5d8c7a2a59736b014885c74fc</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/valyala/bytebufferpool@v1.0.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/valyala/bytebufferpool</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/valyala/fasthttp@v1.6.0" type="library">
+      <name>github.com/valyala/fasthttp</name>
+      <version>v1.6.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b9617c9602a679a21ec1654fc22e0646ad8febe478e8881865dc56b4cf86b446</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/valyala/fasthttp@v1.6.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/valyala/fasthttp</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/valyala/fasttemplate@v1.0.1" type="library">
+      <name>github.com/valyala/fasttemplate</name>
+      <version>v1.0.1</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b58f422623e73177f5111986d84c8aee035477e73a44a183d087d4f167544b3f</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/valyala/fasttemplate@v1.0.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/valyala/fasttemplate</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/valyala/tcplisten@v0.0.0-20161114210144-ceec8f93295a" type="library">
+      <name>github.com/valyala/tcplisten</name>
+      <version>v0.0.0-20161114210144-ceec8f93295a</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">d11e0d2c3443657e897268498178b91386fc5a0f388a16e650aa7f1af48f1337</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/valyala/tcplisten@v0.0.0-20161114210144-ceec8f93295a</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/valyala/tcplisten</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/vmihailenco/msgpack/v5@v5.1.3" type="library">
+      <name>github.com/vmihailenco/msgpack/v5</name>
+      <version>v5.1.3</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">1700bd28f8f25bc3aa4d4a8cb7aad0c3dcb9d2f0367132d73ca09c04245b4208</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>BSD-2-Clause</id>
+          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/vmihailenco/msgpack/v5@v5.1.3</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/vmihailenco/msgpack/v5</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/vmihailenco/tagparser@v0.1.2" type="library">
+      <name>github.com/vmihailenco/tagparser</name>
+      <version>v0.1.2</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">8278e856e07f9258c9e702021043a9c7df285cc58f2e3db61baed56ddd6a3ea7</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>BSD-2-Clause</id>
+          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/vmihailenco/tagparser@v0.1.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/vmihailenco/tagparser</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/xeipuuv/gojsonpointer@v0.0.0-20180127040702-4e3ac2762d5f" type="library">
+      <name>github.com/xeipuuv/gojsonpointer</name>
+      <version>v0.0.0-20180127040702-4e3ac2762d5f</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">27d106a5c66d3f413fadaa2b08cc6514649306bb1295a0c67f78d4feabc01367</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <name>Apache License 2.0</name>
+          <url>https://spdx.org/licenses/Apache-2.0.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/xeipuuv/gojsonpointer@v0.0.0-20180127040702-4e3ac2762d5f</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/xeipuuv/gojsonpointer</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/xeipuuv/gojsonreference@v0.0.0-20180127040603-bd5ef7bd5415" type="library">
+      <name>github.com/xeipuuv/gojsonreference</name>
+      <version>v0.0.0-20180127040603-bd5ef7bd5415</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">133256807a2fa27b7b36c723a40c57b0303c4bc04c62f7bc639fbb72e444ed1d</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <name>Apache License 2.0</name>
+          <url>https://spdx.org/licenses/Apache-2.0.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/xeipuuv/gojsonreference@v0.0.0-20180127040603-bd5ef7bd5415</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/xeipuuv/gojsonreference</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/xeipuuv/gojsonschema@v1.2.0" type="library">
+      <name>github.com/xeipuuv/gojsonschema</name>
+      <version>v1.2.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">2e160946cf8be1f06d8d951fb92648286795bb4411cbc7b95e2ec3d7b53167be</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <name>Apache License 2.0</name>
+          <url>https://spdx.org/licenses/Apache-2.0.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/xeipuuv/gojsonschema@v1.2.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/xeipuuv/gojsonschema</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/xordataexchange/crypt@v0.0.3-0.20170626215501-b2862e3d0a77" type="library">
+      <name>github.com/xordataexchange/crypt</name>
+      <version>v0.0.3-0.20170626215501-b2862e3d0a77</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">112152770619be47abbb746d76b62e7b3b4a84e0424800334b819ffa4d2d128c</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/xordataexchange/crypt@v0.0.3-0.20170626215501-b2862e3d0a77</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/xordataexchange/crypt</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/yalp/jsonpath@v0.0.0-20180802001716-5cc68e5049a0" type="library">
+      <name>github.com/yalp/jsonpath</name>
+      <version>v0.0.0-20180802001716-5cc68e5049a0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">e9f4614a380b0a44c3dc99c9c6f689e128fe4d86e5c3be7b6ea62065a3aae596</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/yalp/jsonpath@v0.0.0-20180802001716-5cc68e5049a0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/yalp/jsonpath</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/yudai/gojsondiff@v1.0.0" type="library">
+      <name>github.com/yudai/gojsondiff</name>
+      <version>v1.0.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">dbb71b7ea5cb544275a3c23abf7cbd960f18766e7710aa875c038cc441a508e0</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/yudai/gojsondiff@v1.0.0</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/yudai/gojsondiff</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/yudai/golcs@v0.0.0-20170316035057-ecda9a501e82" type="library">
+      <name>github.com/yudai/golcs</name>
+      <version>v0.0.0-20170316035057-ecda9a501e82</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">047c9f2a5432a9bb05379a7721f9c451db96bdbf62b38dbcfe735be4bdd4d353</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/yudai/golcs@v0.0.0-20170316035057-ecda9a501e82</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/yudai/golcs</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/github.com/yudai/pp@v2.0.1" type="library">
+      <name>github.com/yudai/pp</name>
+      <version>v2.0.1</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">1299f78b400318def5807e58bf26b725c8d0ac5fcab8b1c798ffc31b0f73d730</hash>
+      </hashes>
+      <purl>pkg:golang/github.com/yudai/pp@v2.0.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/yudai/pp</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/go.etcd.io/bbolt@v1.3.5" type="library">
+      <name>go.etcd.io/bbolt</name>
+      <version>v1.3.5</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">5c0cf1f608c26f44718fb128a9c0a53c3d5de590716499348dbba83c77a706dd</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/go.etcd.io/bbolt@v1.3.5</purl>
+    </component>
+    <component bom-ref="pkg:golang/github.com/ProtonMail/crypto@v0.0.0-20201112115411-41db4ea0dd1c" type="library">
+      <name>github.com/ProtonMail/crypto</name>
+      <version>v0.0.0-20201112115411-41db4ea0dd1c</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">89a55b10e9ec9121a0707ed74161c6e953e2ac70d1a187be21d774fdd9789bc0</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/ProtonMail/crypto@v0.0.0-20201112115411-41db4ea0dd1c</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/ProtonMail/crypto</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/golang.org/x/exp@v0.0.0-20190731235908-ec7cb31e5a56" type="library">
+      <name>golang.org/x/exp</name>
+      <version>v0.0.0-20190731235908-ec7cb31e5a56</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">7acb64d6094e9d255e27db5d11965ce6600c0d993994d24dc89e83beb0644c45</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/golang.org/x/exp@v0.0.0-20190731235908-ec7cb31e5a56</purl>
+    </component>
+    <component bom-ref="pkg:golang/golang.org/x/image@v0.0.0-20190802002840-cff245a6509b" type="library">
+      <name>golang.org/x/image</name>
+      <version>v0.0.0-20190802002840-cff245a6509b</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">faa1291003e10d9d68d31ded1f365340302b9ce8b13b3183f475097dc83499be</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/golang.org/x/image@v0.0.0-20190802002840-cff245a6509b</purl>
+    </component>
+    <component bom-ref="pkg:golang/golang.org/x/mobile@v0.0.0-20200801112145-973feb4309de" type="library">
+      <name>golang.org/x/mobile</name>
+      <version>v0.0.0-20200801112145-973feb4309de</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">39527a41050101eb01f026628ca0d2b175fbc5856d521ae463483031f6e2e29e</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/golang.org/x/mobile@v0.0.0-20200801112145-973feb4309de</purl>
+    </component>
+    <component bom-ref="pkg:golang/golang.org/x/mod@v0.1.1-0.20191209134235-331c550502dd" type="library">
+      <name>golang.org/x/mod</name>
+      <version>v0.1.1-0.20191209134235-331c550502dd</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">78fb8d0bb3d9e8ee41ce03e7f5b65ac8445705d7d98d46285c47f90537c37e1f</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/golang.org/x/mod@v0.1.1-0.20191209134235-331c550502dd</purl>
+    </component>
+    <component bom-ref="pkg:golang/golang.org/x/net@v0.0.0-20200707034311-ab3426394381" type="library">
+      <name>golang.org/x/net</name>
+      <version>v0.0.0-20200707034311-ab3426394381</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">5576a4e48e9a1169805de42303e41267396036ba6af668dc7c37a6b9ec482ac5</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/golang.org/x/net@v0.0.0-20200707034311-ab3426394381</purl>
+    </component>
+    <component bom-ref="pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e" type="library">
+      <name>golang.org/x/sync</name>
+      <version>v0.0.0-20190911185100-cd5d95a43a6e</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">bdcc466a84ecee457c9b9369f6e50d4229f806b2ceb61815ef6e7637c57e1706</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e</purl>
+    </component>
+    <component bom-ref="pkg:golang/golang.org/x/sys@v0.0.0-20200323222414-85ca7c5b95cd" type="library">
+      <name>golang.org/x/sys</name>
+      <version>v0.0.0-20200323222414-85ca7c5b95cd</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c619b0caf8b3b93802daacfb665325b8fdb4b96f82dd19b4143fd62c35fcf3ce</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/golang.org/x/sys@v0.0.0-20200323222414-85ca7c5b95cd</purl>
+    </component>
+    <component bom-ref="pkg:golang/golang.org/x/term@v0.0.0-20201117132131-f5c789dd3221" type="library">
+      <name>golang.org/x/term</name>
+      <version>v0.0.0-20201117132131-f5c789dd3221</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">fd91dd6d5a5d47f8e4de0df4fdde3250bd0953d924b23f3e17f6e741454b1833</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/golang.org/x/term@v0.0.0-20201117132131-f5c789dd3221</purl>
+    </component>
+    <component bom-ref="pkg:golang/golang.org/x/text@v0.3.5-0.20201125200606-c27b9fd57aec" type="library">
+      <name>golang.org/x/text</name>
+      <version>v0.3.5-0.20201125200606-c27b9fd57aec</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">035a988e7789bb305967680807caddeb3adfaba97b4a810c27c12c4a294d2bf5</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/golang.org/x/text@v0.3.5-0.20201125200606-c27b9fd57aec</purl>
+    </component>
+    <component bom-ref="pkg:golang/golang.org/x/tools@v0.0.0-20200117012304-6edc0a871e69" type="library">
+      <name>golang.org/x/tools</name>
+      <version>v0.0.0-20200117012304-6edc0a871e69</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c811c7c7e5d9a972419ba13191edcded5f609e5b325f1a023c46f5c957a78df9</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/golang.org/x/tools@v0.0.0-20200117012304-6edc0a871e69</purl>
+    </component>
+    <component bom-ref="pkg:golang/golang.org/x/xerrors@v0.0.0-20191204190536-9bdfabe68543" type="library">
+      <name>golang.org/x/xerrors</name>
+      <version>v0.0.0-20191204190536-9bdfabe68543</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">13b83ef46213ab4ee1a5fad1bbae885437b131a91fbf9d9e2d9d825c15a22abe</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/golang.org/x/xerrors@v0.0.0-20191204190536-9bdfabe68543</purl>
+    </component>
+    <component bom-ref="pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f" type="library">
+      <name>gopkg.in/check.v1</name>
+      <version>v1.0.0-20200227125254-8fa46927fb4f</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">04bada1579e6adebf9953fb196296a707f172bdfe2d00b76c4a8d6938a7acec5</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>BSD-2-Clause</id>
+          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/go-check/check</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/gopkg.in/fsnotify.v1@v1.4.7" type="library">
+      <name>gopkg.in/fsnotify.v1</name>
+      <version>v1.4.7</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c4e1cb5d9c15bc8f6186cf9c2caab9f88e689cebb040b850c22bbadf1c651ece</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/gopkg.in/fsnotify.v1@v1.4.7</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/go-fsnotify/fsnotify</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/gopkg.in/go-playground/assert.v1@v1.2.1" type="library">
+      <name>gopkg.in/go-playground/assert.v1</name>
+      <version>v1.2.1</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c6862e25513b293f393d85ab37bdf4460b8840ed1e3f35517c531769d22b5d33</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/gopkg.in/go-playground/assert.v1@v1.2.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/go-playground/assert</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/gopkg.in/go-playground/validator.v8@v8.18.2" type="library">
+      <name>gopkg.in/go-playground/validator.v8</name>
+      <version>v8.18.2</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">9450780e8314e81eb6eb0f27cbbe8c57b557e96d951dcb76195388df182232b4</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/gopkg.in/go-playground/validator.v8@v8.18.2</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/go-playground/validator</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/gopkg.in/ini.v1@v1.51.1" type="library">
+      <name>gopkg.in/ini.v1</name>
+      <version>v1.51.1</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">1b26e81ebe14a8c88b5326d88dddb6663408284244a60b4b5edb866d1db53a1a</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <name>Apache License 2.0</name>
+          <url>https://spdx.org/licenses/Apache-2.0.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/gopkg.in/ini.v1@v1.51.1</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/go-ini/ini</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/gopkg.in/mgo.v2@v2.0.0-20180705113604-9856a29383ce" type="library">
+      <name>gopkg.in/mgo.v2</name>
+      <version>v2.0.0-20180705113604-9856a29383ce</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">c5c1168d586f6c3cbe9c73faee73c30e96d8ad8f882e57e7764e1b462a151da5</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>BSD-2-Clause</id>
+          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/gopkg.in/mgo.v2@v2.0.0-20180705113604-9856a29383ce</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/go-mgo/mgo</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7" type="library">
+      <name>gopkg.in/tomb.v1</name>
+      <version>v1.0.0-20141024135613-dd632973f1e7</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">b9118975c88e1da108af37b65bc43700a91ea4b4e1da13aba13edafbb7337dd4</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/go-tomb/tomb</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/gopkg.in/yaml.v2@v2.2.8" type="library">
+      <name>gopkg.in/yaml.v2</name>
+      <version>v2.2.8</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">a1b37565a809494188d0493f2c19ae8f848d2cf7c89f2dcab0a168a7145d8f5d</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <name>Apache License 2.0</name>
+          <url>https://spdx.org/licenses/Apache-2.0.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/gopkg.in/yaml.v2@v2.2.8</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/go-yaml/yaml</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component bom-ref="pkg:golang/gopkg.in/yaml.v3@v3.0.0-20200313102051-9f266ea9e77c" type="library">
+      <name>gopkg.in/yaml.v3</name>
+      <version>v3.0.0-20200313102051-9f266ea9e77c</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="SHA-256">7545301e4d90102a3feafa80e38aed859f227b641730d78a4531c2358da75efa</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <name>Apache License 2.0</name>
+          <url>https://spdx.org/licenses/Apache-2.0.html</url>
+        </license>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/gopkg.in/yaml.v3@v3.0.0-20200313102051-9f266ea9e77c</purl>
+      <externalReferences>
+        <reference type="vcs">
+          <url>https://github.com/go-yaml/yaml</url>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="pkg:golang/github.com/0xAX/notificator@v0.0.0-20191016112426-3962a5ea8da1"></dependency>
+    <dependency ref="pkg:golang/github.com/AndreasBriese/bbloom@v0.0.0-20190306092124-e2d15f34fcf9"></dependency>
+    <dependency ref="pkg:golang/github.com/BurntSushi/toml@v0.3.1"></dependency>
+    <dependency ref="pkg:golang/github.com/BurntSushi/xgb@v0.0.0-20160522181843-27f122750802"></dependency>
+    <dependency ref="pkg:golang/github.com/CloudyKit/fastprinter@v0.0.0-20200109182630-33d98a066a53"></dependency>
+    <dependency ref="pkg:golang/github.com/CloudyKit/jet/v3@v3.0.0">
+      <dependency ref="pkg:golang/github.com/CloudyKit/fastprinter@v0.0.0-20200109182630-33d98a066a53"></dependency>
+    </dependency>
+    <dependency ref="pkg:golang/github.com/Joker/hpp@v1.0.0"></dependency>
+    <dependency ref="pkg:golang/github.com/Masterminds/semver/v3@v3.1.0"></dependency>
+    <dependency ref="pkg:golang/github.com/ProtonMail/go-autostart@v0.0.0-20181114175602-c5272053443a"></dependency>
+    <dependency ref="pkg:golang/github.com/ProtonMail/go-crypto@v0.0.0-20201208171014-cdb7591792e2">
+      <dependency ref="pkg:golang/golang.org/x/term@v0.0.0-20201117132131-f5c789dd3221"></dependency>
+    </dependency>
+    <dependency ref="pkg:golang/github.com/ProtonMail/go-imap-id@v0.0.0-20190926060100-f94a56b9ecde"></dependency>
+    <dependency ref="pkg:golang/github.com/ProtonMail/go-mime@v0.0.0-20190923161245-9b5a4261663a"></dependency>
+    <dependency ref="pkg:golang/github.com/ProtonMail/go-rfc5322@v0.5.0">
+      <dependency ref="pkg:golang/github.com/antlr/antlr4@v0.0.0-20201029161626-9a95f0cc3d7c"></dependency>
+      <dependency ref="pkg:golang/github.com/sirupsen/logrus@v1.7.0"></dependency>
+      <dependency ref="pkg:golang/github.com/stretchr/testify@v1.6.1"></dependency>
+    </dependency>
+    <dependency ref="pkg:golang/github.com/ProtonMail/go-vcard@v0.0.0-20180326232728-33aaa0a0c8a5"></dependency>
+    <dependency ref="pkg:golang/github.com/ProtonMail/gopenpgp/v2@v2.1.3">
+      <dependency ref="pkg:golang/github.com/ProtonMail/go-crypto@v0.0.0-20201208171014-cdb7591792e2"></dependency>
+      <dependency ref="pkg:golang/github.com/ProtonMail/go-mime@v0.0.0-20190923161245-9b5a4261663a"></dependency>
+      <dependency ref="pkg:golang/golang.org/x/mobile@v0.0.0-20200801112145-973feb4309de"></dependency>
+    </dependency>
+    <dependency ref="pkg:golang/github.com/PuerkitoBio/goquery@v1.5.1">
+      <dependency ref="pkg:golang/github.com/andybalholm/cascadia@v1.1.0"></dependency>
+    </dependency>
+    <dependency ref="pkg:golang/github.com/Shopify/goreferrer@v0.0.0-20181106222321-ec9c9a553398"></dependency>
+    <dependency ref="pkg:golang/github.com/abiosoft/ishell@v2.0.0"></dependency>
+    <dependency ref="pkg:golang/github.com/abiosoft/readline@v0.0.0-20180607040430-155bce2042db"></dependency>
+    <dependency ref="pkg:golang/github.com/ajg/form@v1.5.1"></dependency>
+    <dependency ref="pkg:golang/github.com/allan-simon/go-singleinstance@v0.0.0-20160830203053-79edcfdc2dfc"></dependency>
+    <dependency ref="pkg:golang/github.com/andybalholm/cascadia@v1.1.0"></dependency>
+    <dependency ref="pkg:golang/github.com/antlr/antlr4@v0.0.0-20201029161626-9a95f0cc3d7c"></dependency>
+    <dependency ref="pkg:golang/github.com/armon/consul-api@v0.0.0-20180202201655-eb2c6b5be1b6"></dependency>
+    <dependency ref="pkg:golang/github.com/aymerick/raymond@v2.0.3-0.20180322193309-b565731e1464"></dependency>
+    <dependency ref="pkg:golang/github.com/chzyer/logex@v1.1.10"></dependency>
+    <dependency ref="pkg:golang/github.com/chzyer/test@v0.0.0-20180213035817-a1ea475d72b1"></dependency>
+    <dependency ref="pkg:golang/github.com/codegangsta/inject@v0.0.0-20150114235600-33e0aa1cb7c0"></dependency>
+    <dependency ref="pkg:golang/github.com/coreos/etcd@v3.3.10"></dependency>
+    <dependency ref="pkg:golang/github.com/coreos/go-etcd@v2.0.0"></dependency>
+    <dependency ref="pkg:golang/github.com/coreos/go-semver@v0.2.0"></dependency>
+    <dependency ref="pkg:golang/github.com/cpuguy83/go-md2man@v1.0.10">
+      <dependency ref="pkg:golang/github.com/russross/blackfriday@v1.5.2"></dependency>
+    </dependency>
+    <dependency ref="pkg:golang/github.com/cpuguy83/go-md2man/v2@v2.0.0-20190314233015-f79a8a8ca69d">
+      <dependency ref="pkg:golang/github.com/pmezard/go-difflib@v1.0.0"></dependency>
+      <dependency ref="pkg:golang/github.com/russross/blackfriday/v2@v2.0.1"></dependency>
+      <dependency ref="pkg:golang/github.com/shurcooL/sanitized_anchor_name@v1.0.0"></dependency>
+    </dependency>
+    <dependency ref="pkg:golang/github.com/creack/pty@v1.1.9"></dependency>
+    <dependency ref="pkg:golang/github.com/cucumber/godog@v0.8.1"></dependency>
+    <dependency ref="pkg:golang/github.com/danieljoos/wincred@v1.1.0"></dependency>
+    <dependency ref="pkg:golang/github.com/davecgh/go-spew@v1.1.1"></dependency>
+    <dependency ref="pkg:golang/github.com/dgraph-io/badger@v1.6.0">
+      <dependency ref="pkg:golang/github.com/AndreasBriese/bbloom@v0.0.0-20190306092124-e2d15f34fcf9"></dependency>
+      <dependency ref="pkg:golang/github.com/dgryski/go-farm@v0.0.0-20190423205320-6a90982ecee2"></dependency>
+      <dependency ref="pkg:golang/github.com/dustin/go-humanize@v1.0.0"></dependency>
+      <dependency ref="pkg:golang/github.com/golang/protobuf@v1.3.1"></dependency>
+      <dependency ref="pkg:golang/github.com/spf13/cobra@v0.0.5"></dependency>
+    </dependency>
+    <dependency ref="pkg:golang/github.com/dgrijalva/jwt-go@v3.2.0"></dependency>
+    <dependency ref="pkg:golang/github.com/dgryski/go-farm@v0.0.0-20190423205320-6a90982ecee2"></dependency>
+    <dependency ref="pkg:golang/github.com/ProtonMail/docker-credential-helpers@v1.1.0">
+      <dependency ref="pkg:golang/github.com/danieljoos/wincred@v1.1.0"></dependency>
+    </dependency>
+    <dependency ref="pkg:golang/github.com/dustin/go-humanize@v1.0.0"></dependency>
+    <dependency ref="pkg:golang/github.com/eknkc/amber@v0.0.0-20171010120322-cdade1c07385"></dependency>
+    <dependency ref="pkg:golang/github.com/ProtonMail/go-imap@v0.0.0-20201228133358-4db68cea0cac"></dependency>
+    <dependency ref="pkg:golang/github.com/emersion/go-imap-appendlimit@v0.0.0-20190308131241-25671c986a6a"></dependency>
+    <dependency ref="pkg:golang/github.com/emersion/go-imap-idle@v0.0.0-20200601154248-f05f54664cc4"></dependency>
+    <dependency ref="pkg:golang/github.com/emersion/go-imap-move@v0.0.0-20190710073258-6e5a51a5b342"></dependency>
+    <dependency ref="pkg:golang/github.com/emersion/go-imap-quota@v0.0.0-20200423100218-dcfd1b7d2b41"></dependency>
+    <dependency ref="pkg:golang/github.com/emersion/go-imap-unselect@v0.0.0-20171113212723-b985794e5f26"></dependency>
+    <dependency ref="pkg:golang/github.com/emersion/go-mbox@v1.0.2"></dependency>
+    <dependency ref="pkg:golang/github.com/emersion/go-message@v0.12.1-0.20201221184100-40c3f864532b">
+      <dependency ref="pkg:golang/github.com/davecgh/go-spew@v1.1.1"></dependency>
+      <dependency ref="pkg:golang/github.com/emersion/go-textwrapper@v0.0.0-20200911093747-65d896831594"></dependency>
+      <dependency ref="pkg:golang/github.com/martinlindhe/base36@v1.1.0"></dependency>
+      <dependency ref="pkg:golang/golang.org/x/text@v0.3.5-0.20201125200606-c27b9fd57aec"></dependency>
+    </dependency>
+    <dependency ref="pkg:golang/github.com/emersion/go-sasl@v0.0.0-20200509203442-7bfe0ed36a21"></dependency>
+    <dependency ref="pkg:golang/github.com/emersion/go-smtp@v0.14.0">
+      <dependency ref="pkg:golang/github.com/emersion/go-sasl@v0.0.0-20200509203442-7bfe0ed36a21"></dependency>
+    </dependency>
+    <dependency ref="pkg:golang/github.com/emersion/go-textwrapper@v0.0.0-20200911093747-65d896831594"></dependency>
+    <dependency ref="pkg:golang/github.com/emersion/go-vcard@v0.0.0-20190105225839-8856043f13c5"></dependency>
+    <dependency ref="pkg:golang/github.com/etcd-io/bbolt@v1.3.3"></dependency>
+    <dependency ref="pkg:golang/github.com/fasthttp-contrib/websocket@v0.0.0-20160511215533-1f3b11f56072"></dependency>
+    <dependency ref="pkg:golang/github.com/fatih/color@v1.9.0">
+      <dependency ref="pkg:golang/github.com/mattn/go-colorable@v0.1.4"></dependency>
+      <dependency ref="pkg:golang/github.com/mattn/go-isatty@v0.0.11"></dependency>
+    </dependency>
+    <dependency ref="pkg:golang/github.com/fatih/structs@v1.1.0"></dependency>
+    <dependency ref="pkg:golang/github.com/flynn-archive/go-shlex@v0.0.0-20150515145356-3f9db97f8568"></dependency>
+    <dependency ref="pkg:golang/github.com/fsnotify/fsnotify@v1.4.7"></dependency>
+    <dependency ref="pkg:golang/github.com/gavv/httpexpect@v2.0.0"></dependency>
+    <dependency ref="pkg:golang/github.com/getsentry/sentry-go@v0.8.0">
+      <dependency ref="pkg:golang/github.com/ajg/form@v1.5.1"></dependency>
+      <dependency ref="pkg:golang/github.com/codegangsta/inject@v0.0.0-20150114235600-33e0aa1cb7c0"></dependency>
+      <dependency ref="pkg:golang/github.com/fasthttp-contrib/websocket@v0.0.0-20160511215533-1f3b11f56072"></dependency>
+      <dependency ref="pkg:golang/github.com/gin-gonic/gin@v1.4.0"></dependency>
+      <dependency ref="pkg:golang/github.com/go-errors/errors@v1.0.1"></dependency>
+      <dependency ref="pkg:golang/github.com/go-martini/martini@v0.0.0-20170121215854-22fa46961aab"></dependency>
+      <dependency ref="pkg:golang/github.com/google/go-querystring@v1.0.0"></dependency>
+      <dependency ref="pkg:golang/github.com/imkira/go-interpol@v1.1.0"></dependency>
+      <dependency ref="pkg:golang/github.com/k0kubun/colorstring@v0.0.0-20150214042306-9440f1994b88"></dependency>
+      <dependency ref="pkg:golang/github.com/kataras/iris/v12@v12.1.8"></dependency>
+      <dependency ref="pkg:golang/github.com/labstack/echo/v4@v4.1.11"></dependency>
+      <dependency ref="pkg:golang/github.com/moul/http2curl@v1.0.0"></dependency>
+      <dependency ref="pkg:golang/github.com/onsi/ginkgo@v1.10.3"></dependency>
+      <dependency ref="pkg:golang/github.com/onsi/gomega@v1.7.1"></dependency>
+      <dependency ref="pkg:golang/github.com/pingcap/errors@v0.11.4"></dependency>
+      <dependency ref="pkg:golang/github.com/sergi/go-diff@v1.0.0"></dependency>
+      <dependency ref="pkg:golang/github.com/shurcooL/sanitized_anchor_name@v1.0.0"></dependency>
+      <dependency ref="pkg:golang/github.com/smartystreets/goconvey@v1.6.4"></dependency>
+      <dependency ref="pkg:golang/github.com/ugorji/go@v1.1.7"></dependency>
+      <dependency ref="pkg:golang/github.com/urfave/negroni@v1.0.0"></dependency>
+      <dependency ref="pkg:golang/github.com/valyala/fasthttp@v1.6.0"></dependency>
+      <dependency ref="pkg:golang/github.com/xeipuuv/gojsonschema@v1.2.0"></dependency>
+      <dependency ref="pkg:golang/github.com/yalp/jsonpath@v0.0.0-20180802001716-5cc68e5049a0"></dependency>
+      <dependency ref="pkg:golang/github.com/yudai/gojsondiff@v1.0.0"></dependency>
+      <dependency ref="pkg:golang/github.com/yudai/golcs@v0.0.0-20170316035057-ecda9a501e82"></dependency>
+      <dependency ref="pkg:golang/github.com/yudai/pp@v2.0.1"></dependency>
+    </dependency>
+    <dependency ref="pkg:golang/github.com/gin-contrib/sse@v0.0.0-20190301062529-5545eab6dad3"></dependency>
+    <dependency ref="pkg:golang/github.com/gin-gonic/gin@v1.4.0">
+      <dependency ref="pkg:golang/github.com/gin-contrib/sse@v0.0.0-20190301062529-5545eab6dad3"></dependency>
+      <dependency ref="pkg:golang/github.com/golang/protobuf@v1.3.1"></dependency>
+      <dependency ref="pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd"></dependency>
+      <dependency ref="pkg:golang/github.com/modern-go/reflect2@v1.0.1"></dependency>
+      <dependency ref="pkg:golang/gopkg.in/go-playground/assert.v1@v1.2.1"></dependency>
+      <dependency ref="pkg:golang/gopkg.in/go-playground/validator.v8@v8.18.2"></dependency>
+    </dependency>
+    <dependency ref="pkg:golang/github.com/go-check/check@v0.0.0-20180628173108-788fd7840127"></dependency>
+    <dependency ref="pkg:golang/github.com/go-errors/errors@v1.0.1"></dependency>
+    <dependency ref="pkg:golang/github.com/go-martini/martini@v0.0.0-20170121215854-22fa46961aab"></dependency>
+    <dependency ref="pkg:golang/github.com/go-resty/resty/v2@v2.3.0"></dependency>
+    <dependency ref="pkg:golang/github.com/gobwas/httphead@v0.0.0-20180130184737-2c6c146eadee"></dependency>
+    <dependency ref="pkg:golang/github.com/gobwas/pool@v0.2.0"></dependency>
+    <dependency ref="pkg:golang/github.com/gobwas/ws@v1.0.2"></dependency>
+    <dependency ref="pkg:golang/github.com/golang/mock@v1.4.4"></dependency>
+    <dependency ref="pkg:golang/github.com/golang/protobuf@v1.3.1"></dependency>
+    <dependency ref="pkg:golang/github.com/gomodule/redigo@v1.7.1-0.20190724094224-574c33c3df38"></dependency>
+    <dependency ref="pkg:golang/github.com/google/go-cmp@v0.5.1">
+      <dependency ref="pkg:golang/golang.org/x/xerrors@v0.0.0-20191204190536-9bdfabe68543"></dependency>
+    </dependency>
+    <dependency ref="pkg:golang/github.com/google/go-querystring@v1.0.0"></dependency>
+    <dependency ref="pkg:golang/github.com/google/gofuzz@v1.0.0"></dependency>
+    <dependency ref="pkg:golang/github.com/google/uuid@v1.1.1"></dependency>
+    <dependency ref="pkg:golang/github.com/gopherjs/gopherjs@v0.0.0-20190430165422-3e4dfb77656c"></dependency>
+    <dependency ref="pkg:golang/github.com/gorilla/websocket@v1.4.1"></dependency>
+    <dependency ref="pkg:golang/github.com/hashicorp/errwrap@v1.0.0"></dependency>
+    <dependency ref="pkg:golang/github.com/hashicorp/go-multierror@v1.1.0">
+      <dependency ref="pkg:golang/github.com/hashicorp/errwrap@v1.0.0"></dependency>
+    </dependency>
+    <dependency ref="pkg:golang/github.com/hashicorp/go-version@v1.2.0"></dependency>
+    <dependency ref="pkg:golang/github.com/hashicorp/hcl@v1.0.0">
+      <dependency ref="pkg:golang/github.com/davecgh/go-spew@v1.1.1"></dependency>
+    </dependency>
+    <dependency ref="pkg:golang/github.com/hpcloud/tail@v1.0.0"></dependency>
+    <dependency ref="pkg:golang/github.com/imkira/go-interpol@v1.1.0"></dependency>
+    <dependency ref="pkg:golang/github.com/inconshreveable/mousetrap@v1.0.0"></dependency>
+    <dependency ref="pkg:golang/github.com/iris-contrib/blackfriday@v2.0.0"></dependency>
+    <dependency ref="pkg:golang/github.com/iris-contrib/go.uuid@v2.0.0"></dependency>
+    <dependency ref="pkg:golang/github.com/iris-contrib/jade@v1.1.3">
+      <dependency ref="pkg:golang/github.com/Joker/hpp@v1.0.0"></dependency>
+      <dependency ref="pkg:golang/github.com/valyala/bytebufferpool@v1.0.0"></dependency>
+    </dependency>
+    <dependency ref="pkg:golang/github.com/iris-contrib/pongo2@v0.0.1">
+      <dependency ref="pkg:golang/github.com/go-check/check@v0.0.0-20180628173108-788fd7840127"></dependency>
+      <dependency ref="pkg:golang/github.com/kr/pretty@v0.1.0"></dependency>
+      <dependency ref="pkg:golang/github.com/mattn/goveralls@v0.0.2"></dependency>
+      <dependency ref="pkg:golang/gopkg.in/mgo.v2@v2.0.0-20180705113604-9856a29383ce"></dependency>
+    </dependency>
+    <dependency ref="pkg:golang/github.com/iris-contrib/schema@v0.0.1"></dependency>
+    <dependency ref="pkg:golang/github.com/ProtonMail/bcrypt@v0.0.0-20170924085257-7509ea014998"></dependency>
+    <dependency ref="pkg:golang/github.com/jaytaylor/html2text@v0.0.0-20200412013138-3577fbdbcff7"></dependency>
+    <dependency ref="pkg:golang/github.com/json-iterator/go@v1.1.9">
+      <dependency ref="pkg:golang/github.com/davecgh/go-spew@v1.1.1"></dependency>
+      <dependency ref="pkg:golang/github.com/google/gofuzz@v1.0.0"></dependency>
+    </dependency>
+    <dependency ref="pkg:golang/github.com/jtolds/gls@v4.20.0"></dependency>
+    <dependency ref="pkg:golang/github.com/k0kubun/colorstring@v0.0.0-20150214042306-9440f1994b88"></dependency>
+    <dependency ref="pkg:golang/github.com/kataras/golog@v0.0.10">
+      <dependency ref="pkg:golang/github.com/kataras/pio@v0.0.2"></dependency>
+    </dependency>
+    <dependency ref="pkg:golang/github.com/kataras/iris/v12@v12.1.8">
+      <dependency ref="pkg:golang/github.com/BurntSushi/toml@v0.3.1"></dependency>
+      <dependency ref="pkg:golang/github.com/CloudyKit/jet/v3@v3.0.0"></dependency>
+      <dependency ref="pkg:golang/github.com/Shopify/goreferrer@v0.0.0-20181106222321-ec9c9a553398"></dependency>
+      <dependency ref="pkg:golang/github.com/aymerick/raymond@v2.0.3-0.20180322193309-b565731e1464"></dependency>
+      <dependency ref="pkg:golang/github.com/dgraph-io/badger@v1.6.0"></dependency>
+      <dependency ref="pkg:golang/github.com/eknkc/amber@v0.0.0-20171010120322-cdade1c07385"></dependency>
+      <dependency ref="pkg:golang/github.com/etcd-io/bbolt@v1.3.3"></dependency>
+      <dependency ref="pkg:golang/github.com/fatih/structs@v1.1.0"></dependency>
+      <dependency ref="pkg:golang/github.com/gavv/httpexpect@v2.0.0"></dependency>
+      <dependency ref="pkg:golang/github.com/gomodule/redigo@v1.7.1-0.20190724094224-574c33c3df38"></dependency>
+      <dependency ref="pkg:golang/github.com/hashicorp/go-version@v1.2.0"></dependency>
+      <dependency ref="pkg:golang/github.com/iris-contrib/blackfriday@v2.0.0"></dependency>
+      <dependency ref="pkg:golang/github.com/iris-contrib/go.uuid@v2.0.0"></dependency>
+      <dependency ref="pkg:golang/github.com/iris-contrib/pongo2@v0.0.1"></dependency>
+      <dependency ref="pkg:golang/github.com/iris-contrib/schema@v0.0.1"></dependency>
+      <dependency ref="pkg:golang/github.com/iris-contrib/jade@v1.1.3"></dependency>
+      <dependency ref="pkg:golang/github.com/json-iterator/go@v1.1.9"></dependency>
+      <dependency ref="pkg:golang/github.com/kataras/golog@v0.0.10"></dependency>
+      <dependency ref="pkg:golang/github.com/kataras/neffos@v0.0.14"></dependency>
+      <dependency ref="pkg:golang/github.com/kataras/sitemap@v0.0.5"></dependency>
+      <dependency ref="pkg:golang/github.com/klauspost/compress@v1.9.7"></dependency>
+      <dependency ref="pkg:golang/github.com/mediocregopher/radix/v3@v3.4.2"></dependency>
+      <dependency ref="pkg:golang/github.com/microcosm-cc/bluemonday@v1.0.2"></dependency>
+      <dependency ref="pkg:golang/github.com/ryanuber/columnize@v2.1.0"></dependency>
+      <dependency ref="pkg:golang/github.com/schollz/closestmatch@v2.1.0"></dependency>
+      <dependency ref="pkg:golang/gopkg.in/ini.v1@v1.51.1"></dependency>
+    </dependency>
+    <dependency ref="pkg:golang/github.com/kataras/neffos@v0.0.14">
+      <dependency ref="pkg:golang/github.com/gobwas/httphead@v0.0.0-20180130184737-2c6c146eadee"></dependency>
+      <dependency ref="pkg:golang/github.com/gobwas/pool@v0.2.0"></dependency>
+      <dependency ref="pkg:golang/github.com/gobwas/ws@v1.0.2"></dependency>
+      <dependency ref="pkg:golang/github.com/gorilla/websocket@v1.4.1"></dependency>
+      <dependency ref="pkg:golang/github.com/iris-contrib/go.uuid@v2.0.0"></dependency>
+      <dependency ref="pkg:golang/github.com/mediocregopher/radix/v3@v3.4.2"></dependency>
+      <dependency ref="pkg:golang/github.com/nats-io/nats.go@v1.9.1"></dependency>
+      <dependency ref="pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e"></dependency>
+    </dependency>
+    <dependency ref="pkg:golang/github.com/kataras/pio@v0.0.2"></dependency>
+    <dependency ref="pkg:golang/github.com/kataras/sitemap@v0.0.5"></dependency>
+    <dependency ref="pkg:golang/github.com/keybase/go-keychain@v0.0.0-20200502122510-cda31fe0c86d">
+      <dependency ref="pkg:golang/github.com/davecgh/go-spew@v1.1.1"></dependency>
+      <dependency ref="pkg:golang/github.com/keybase/go.dbus@v0.0.0-20200324223359-a94be52c0b03"></dependency>
+      <dependency ref="pkg:golang/github.com/kr/text@v0.2.0"></dependency>
+      <dependency ref="pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e"></dependency>
+      <dependency ref="pkg:golang/github.com/pkg/errors@v0.9.1"></dependency>
+      <dependency ref="pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f"></dependency>
+      <dependency ref="pkg:golang/gopkg.in/yaml.v2@v2.2.8"></dependency>
+    </dependency>
+    <dependency ref="pkg:golang/github.com/keybase/go.dbus@v0.0.0-20200324223359-a94be52c0b03"></dependency>
+    <dependency ref="pkg:golang/github.com/klauspost/compress@v1.9.7"></dependency>
+    <dependency ref="pkg:golang/github.com/klauspost/cpuid@v1.2.1"></dependency>
+    <dependency ref="pkg:golang/github.com/konsorten/go-windows-terminal-sequences@v1.0.2"></dependency>
+    <dependency ref="pkg:golang/github.com/kr/pretty@v0.1.0"></dependency>
+    <dependency ref="pkg:golang/github.com/kr/pty@v1.1.1"></dependency>
+    <dependency ref="pkg:golang/github.com/kr/text@v0.2.0">
+      <dependency ref="pkg:golang/github.com/creack/pty@v1.1.9"></dependency>
+    </dependency>
+    <dependency ref="pkg:golang/github.com/labstack/echo/v4@v4.1.11">
+      <dependency ref="pkg:golang/github.com/dgrijalva/jwt-go@v3.2.0"></dependency>
+      <dependency ref="pkg:golang/github.com/labstack/gommon@v0.3.0"></dependency>
+      <dependency ref="pkg:golang/github.com/valyala/fasttemplate@v1.0.1"></dependency>
+    </dependency>
+    <dependency ref="pkg:golang/github.com/labstack/gommon@v0.3.0">
+      <dependency ref="pkg:golang/github.com/valyala/fasttemplate@v1.0.1"></dependency>
+    </dependency>
+    <dependency ref="pkg:golang/github.com/logrusorgru/aurora@v2.0.3"></dependency>
+    <dependency ref="pkg:golang/github.com/magiconair/properties@v1.8.0"></dependency>
+    <dependency ref="pkg:golang/github.com/martinlindhe/base36@v1.1.0"></dependency>
+    <dependency ref="pkg:golang/github.com/mattn/go-colorable@v0.1.4"></dependency>
+    <dependency ref="pkg:golang/github.com/mattn/go-isatty@v0.0.11"></dependency>
+    <dependency ref="pkg:golang/github.com/mattn/go-runewidth@v0.0.9"></dependency>
+    <dependency ref="pkg:golang/github.com/mattn/goveralls@v0.0.2"></dependency>
+    <dependency ref="pkg:golang/github.com/mediocregopher/radix/v3@v3.4.2">
+      <dependency ref="pkg:golang/github.com/davecgh/go-spew@v1.1.1"></dependency>
+      <dependency ref="pkg:golang/github.com/pmezard/go-difflib@v1.0.0"></dependency>
+    </dependency>
+    <dependency ref="pkg:golang/github.com/microcosm-cc/bluemonday@v1.0.2"></dependency>
+    <dependency ref="pkg:golang/github.com/miekg/dns@v1.1.30"></dependency>
+    <dependency ref="pkg:golang/github.com/mitchellh/go-homedir@v1.1.0"></dependency>
+    <dependency ref="pkg:golang/github.com/mitchellh/mapstructure@v1.1.2"></dependency>
+    <dependency ref="pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd"></dependency>
+    <dependency ref="pkg:golang/github.com/modern-go/reflect2@v1.0.1"></dependency>
+    <dependency ref="pkg:golang/github.com/moul/http2curl@v1.0.0"></dependency>
+    <dependency ref="pkg:golang/github.com/nats-io/jwt@v0.3.0">
+      <dependency ref="pkg:golang/github.com/nats-io/nkeys@v0.1.0"></dependency>
+    </dependency>
+    <dependency ref="pkg:golang/github.com/nats-io/nats.go@v1.9.1">
+      <dependency ref="pkg:golang/github.com/nats-io/jwt@v0.3.0"></dependency>
+      <dependency ref="pkg:golang/github.com/nats-io/nkeys@v0.1.0"></dependency>
+      <dependency ref="pkg:golang/github.com/nats-io/nuid@v1.0.1"></dependency>
+    </dependency>
+    <dependency ref="pkg:golang/github.com/nats-io/nkeys@v0.1.0"></dependency>
+    <dependency ref="pkg:golang/github.com/nats-io/nuid@v1.0.1"></dependency>
+    <dependency ref="pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e"></dependency>
+    <dependency ref="pkg:golang/github.com/nsf/jsondiff@v0.0.0-20200515183724-f29ed568f4ce"></dependency>
+    <dependency ref="pkg:golang/github.com/olekukonko/tablewriter@v0.0.4"></dependency>
+    <dependency ref="pkg:golang/github.com/onsi/ginkgo@v1.10.3"></dependency>
+    <dependency ref="pkg:golang/github.com/onsi/gomega@v1.7.1">
+      <dependency ref="pkg:golang/github.com/fsnotify/fsnotify@v1.4.7"></dependency>
+      <dependency ref="pkg:golang/github.com/hpcloud/tail@v1.0.0"></dependency>
+      <dependency ref="pkg:golang/gopkg.in/fsnotify.v1@v1.4.7"></dependency>
+      <dependency ref="pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7"></dependency>
+    </dependency>
+    <dependency ref="pkg:golang/github.com/pelletier/go-toml@v1.2.0"></dependency>
+    <dependency ref="pkg:golang/github.com/pingcap/errors@v0.11.4"></dependency>
+    <dependency ref="pkg:golang/github.com/pkg/errors@v0.9.1"></dependency>
+    <dependency ref="pkg:golang/github.com/pmezard/go-difflib@v1.0.0"></dependency>
+    <dependency ref="pkg:golang/github.com/russross/blackfriday@v1.5.2"></dependency>
+    <dependency ref="pkg:golang/github.com/russross/blackfriday/v2@v2.0.1"></dependency>
+    <dependency ref="pkg:golang/github.com/ryanuber/columnize@v2.1.0"></dependency>
+    <dependency ref="pkg:golang/github.com/schollz/closestmatch@v2.1.0"></dependency>
+    <dependency ref="pkg:golang/github.com/sergi/go-diff@v1.0.0"></dependency>
+    <dependency ref="pkg:golang/github.com/shurcooL/sanitized_anchor_name@v1.0.0"></dependency>
+    <dependency ref="pkg:golang/github.com/sirupsen/logrus@v1.7.0">
+      <dependency ref="pkg:golang/github.com/davecgh/go-spew@v1.1.1"></dependency>
+      <dependency ref="pkg:golang/github.com/pmezard/go-difflib@v1.0.0"></dependency>
+    </dependency>
+    <dependency ref="pkg:golang/github.com/skratchdot/open-golang@v0.0.0-20200116055534-eef842397966"></dependency>
+    <dependency ref="pkg:golang/github.com/smartystreets/assertions@v0.0.0-20180927180507-b2de0cb4f26d"></dependency>
+    <dependency ref="pkg:golang/github.com/smartystreets/goconvey@v1.6.4">
+      <dependency ref="pkg:golang/github.com/jtolds/gls@v4.20.0"></dependency>
+      <dependency ref="pkg:golang/github.com/smartystreets/assertions@v0.0.0-20180927180507-b2de0cb4f26d"></dependency>
+    </dependency>
+    <dependency ref="pkg:golang/github.com/spf13/afero@v1.1.2"></dependency>
+    <dependency ref="pkg:golang/github.com/spf13/cast@v1.3.0">
+      <dependency ref="pkg:golang/github.com/davecgh/go-spew@v1.1.1"></dependency>
+      <dependency ref="pkg:golang/github.com/pmezard/go-difflib@v1.0.0"></dependency>
+    </dependency>
+    <dependency ref="pkg:golang/github.com/spf13/cobra@v0.0.5">
+      <dependency ref="pkg:golang/github.com/BurntSushi/toml@v0.3.1"></dependency>
+      <dependency ref="pkg:golang/github.com/cpuguy83/go-md2man@v1.0.10"></dependency>
+      <dependency ref="pkg:golang/github.com/inconshreveable/mousetrap@v1.0.0"></dependency>
+      <dependency ref="pkg:golang/github.com/mitchellh/go-homedir@v1.1.0"></dependency>
+      <dependency ref="pkg:golang/github.com/spf13/pflag@v1.0.3"></dependency>
+      <dependency ref="pkg:golang/github.com/spf13/viper@v1.3.2"></dependency>
+    </dependency>
+    <dependency ref="pkg:golang/github.com/spf13/jwalterweatherman@v1.0.0"></dependency>
+    <dependency ref="pkg:golang/github.com/spf13/pflag@v1.0.3"></dependency>
+    <dependency ref="pkg:golang/github.com/spf13/viper@v1.3.2">
+      <dependency ref="pkg:golang/github.com/armon/consul-api@v0.0.0-20180202201655-eb2c6b5be1b6"></dependency>
+      <dependency ref="pkg:golang/github.com/coreos/etcd@v3.3.10"></dependency>
+      <dependency ref="pkg:golang/github.com/coreos/go-etcd@v2.0.0"></dependency>
+      <dependency ref="pkg:golang/github.com/coreos/go-semver@v0.2.0"></dependency>
+      <dependency ref="pkg:golang/github.com/fsnotify/fsnotify@v1.4.7"></dependency>
+      <dependency ref="pkg:golang/github.com/hashicorp/hcl@v1.0.0"></dependency>
+      <dependency ref="pkg:golang/github.com/magiconair/properties@v1.8.0"></dependency>
+      <dependency ref="pkg:golang/github.com/mitchellh/mapstructure@v1.1.2"></dependency>
+      <dependency ref="pkg:golang/github.com/pelletier/go-toml@v1.2.0"></dependency>
+      <dependency ref="pkg:golang/github.com/spf13/afero@v1.1.2"></dependency>
+      <dependency ref="pkg:golang/github.com/spf13/cast@v1.3.0"></dependency>
+      <dependency ref="pkg:golang/github.com/spf13/jwalterweatherman@v1.0.0"></dependency>
+      <dependency ref="pkg:golang/github.com/spf13/pflag@v1.0.3"></dependency>
+      <dependency ref="pkg:golang/github.com/xordataexchange/crypt@v0.0.3-0.20170626215501-b2862e3d0a77"></dependency>
+    </dependency>
+    <dependency ref="pkg:golang/github.com/ssor/bom@v0.0.0-20170718123548-6386211fdfcf"></dependency>
+    <dependency ref="pkg:golang/github.com/stretchr/objx@v0.2.0">
+      <dependency ref="pkg:golang/github.com/davecgh/go-spew@v1.1.1"></dependency>
+    </dependency>
+    <dependency ref="pkg:golang/github.com/stretchr/testify@v1.6.1">
+      <dependency ref="pkg:golang/github.com/pmezard/go-difflib@v1.0.0"></dependency>
+      <dependency ref="pkg:golang/gopkg.in/yaml.v3@v3.0.0-20200313102051-9f266ea9e77c"></dependency>
+    </dependency>
+    <dependency ref="pkg:golang/github.com/therecipe/qt@v0.0.0-20200701200531-7f61353ee73e">
+      <dependency ref="pkg:golang/github.com/konsorten/go-windows-terminal-sequences@v1.0.2"></dependency>
+      <dependency ref="pkg:golang/github.com/stretchr/objx@v0.2.0"></dependency>
+    </dependency>
+    <dependency ref="pkg:golang/github.com/ugorji/go@v1.1.7">
+      <dependency ref="pkg:golang/github.com/ugorji/go/codec@v1.1.7"></dependency>
+    </dependency>
+    <dependency ref="pkg:golang/github.com/ugorji/go/codec@v1.1.7">
+      <dependency ref="pkg:golang/github.com/ugorji/go@v1.1.7"></dependency>
+    </dependency>
+    <dependency ref="pkg:golang/github.com/urfave/cli/v2@v2.2.0">
+      <dependency ref="pkg:golang/github.com/BurntSushi/toml@v0.3.1"></dependency>
+      <dependency ref="pkg:golang/github.com/cpuguy83/go-md2man/v2@v2.0.0-20190314233015-f79a8a8ca69d"></dependency>
+    </dependency>
+    <dependency ref="pkg:golang/github.com/urfave/negroni@v1.0.0"></dependency>
+    <dependency ref="pkg:golang/github.com/valyala/bytebufferpool@v1.0.0"></dependency>
+    <dependency ref="pkg:golang/github.com/valyala/fasthttp@v1.6.0">
+      <dependency ref="pkg:golang/github.com/klauspost/cpuid@v1.2.1"></dependency>
+      <dependency ref="pkg:golang/github.com/valyala/bytebufferpool@v1.0.0"></dependency>
+      <dependency ref="pkg:golang/github.com/valyala/tcplisten@v0.0.0-20161114210144-ceec8f93295a"></dependency>
+    </dependency>
+    <dependency ref="pkg:golang/github.com/valyala/fasttemplate@v1.0.1">
+      <dependency ref="pkg:golang/github.com/valyala/bytebufferpool@v1.0.0"></dependency>
+    </dependency>
+    <dependency ref="pkg:golang/github.com/valyala/tcplisten@v0.0.0-20161114210144-ceec8f93295a"></dependency>
+    <dependency ref="pkg:golang/github.com/vmihailenco/msgpack/v5@v5.1.3">
+      <dependency ref="pkg:golang/github.com/stretchr/testify@v1.6.1"></dependency>
+      <dependency ref="pkg:golang/github.com/vmihailenco/tagparser@v0.1.2"></dependency>
+    </dependency>
+    <dependency ref="pkg:golang/github.com/vmihailenco/tagparser@v0.1.2"></dependency>
+    <dependency ref="pkg:golang/github.com/xeipuuv/gojsonpointer@v0.0.0-20180127040702-4e3ac2762d5f"></dependency>
+    <dependency ref="pkg:golang/github.com/xeipuuv/gojsonreference@v0.0.0-20180127040603-bd5ef7bd5415"></dependency>
+    <dependency ref="pkg:golang/github.com/xeipuuv/gojsonschema@v1.2.0">
+      <dependency ref="pkg:golang/github.com/xeipuuv/gojsonpointer@v0.0.0-20180127040702-4e3ac2762d5f"></dependency>
+      <dependency ref="pkg:golang/github.com/xeipuuv/gojsonreference@v0.0.0-20180127040603-bd5ef7bd5415"></dependency>
+    </dependency>
+    <dependency ref="pkg:golang/github.com/xordataexchange/crypt@v0.0.3-0.20170626215501-b2862e3d0a77"></dependency>
+    <dependency ref="pkg:golang/github.com/yalp/jsonpath@v0.0.0-20180802001716-5cc68e5049a0"></dependency>
+    <dependency ref="pkg:golang/github.com/yudai/gojsondiff@v1.0.0"></dependency>
+    <dependency ref="pkg:golang/github.com/yudai/golcs@v0.0.0-20170316035057-ecda9a501e82"></dependency>
+    <dependency ref="pkg:golang/github.com/yudai/pp@v2.0.1"></dependency>
+    <dependency ref="pkg:golang/go.etcd.io/bbolt@v1.3.5"></dependency>
+    <dependency ref="pkg:golang/github.com/ProtonMail/crypto@v0.0.0-20201112115411-41db4ea0dd1c"></dependency>
+    <dependency ref="pkg:golang/golang.org/x/exp@v0.0.0-20190731235908-ec7cb31e5a56">
+      <dependency ref="pkg:golang/github.com/BurntSushi/xgb@v0.0.0-20160522181843-27f122750802"></dependency>
+    </dependency>
+    <dependency ref="pkg:golang/golang.org/x/image@v0.0.0-20190802002840-cff245a6509b"></dependency>
+    <dependency ref="pkg:golang/golang.org/x/mobile@v0.0.0-20200801112145-973feb4309de">
+      <dependency ref="pkg:golang/golang.org/x/exp@v0.0.0-20190731235908-ec7cb31e5a56"></dependency>
+      <dependency ref="pkg:golang/golang.org/x/image@v0.0.0-20190802002840-cff245a6509b"></dependency>
+      <dependency ref="pkg:golang/golang.org/x/mod@v0.1.1-0.20191209134235-331c550502dd"></dependency>
+      <dependency ref="pkg:golang/golang.org/x/tools@v0.0.0-20200117012304-6edc0a871e69"></dependency>
+    </dependency>
+    <dependency ref="pkg:golang/golang.org/x/mod@v0.1.1-0.20191209134235-331c550502dd"></dependency>
+    <dependency ref="pkg:golang/golang.org/x/net@v0.0.0-20200707034311-ab3426394381">
+      <dependency ref="pkg:golang/github.com/ProtonMail/crypto@v0.0.0-20201112115411-41db4ea0dd1c"></dependency>
+      <dependency ref="pkg:golang/golang.org/x/sys@v0.0.0-20200323222414-85ca7c5b95cd"></dependency>
+    </dependency>
+    <dependency ref="pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e"></dependency>
+    <dependency ref="pkg:golang/golang.org/x/sys@v0.0.0-20200323222414-85ca7c5b95cd"></dependency>
+    <dependency ref="pkg:golang/golang.org/x/term@v0.0.0-20201117132131-f5c789dd3221"></dependency>
+    <dependency ref="pkg:golang/golang.org/x/text@v0.3.5-0.20201125200606-c27b9fd57aec"></dependency>
+    <dependency ref="pkg:golang/golang.org/x/tools@v0.0.0-20200117012304-6edc0a871e69"></dependency>
+    <dependency ref="pkg:golang/golang.org/x/xerrors@v0.0.0-20191204190536-9bdfabe68543"></dependency>
+    <dependency ref="pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f"></dependency>
+    <dependency ref="pkg:golang/gopkg.in/fsnotify.v1@v1.4.7"></dependency>
+    <dependency ref="pkg:golang/gopkg.in/go-playground/assert.v1@v1.2.1"></dependency>
+    <dependency ref="pkg:golang/gopkg.in/go-playground/validator.v8@v8.18.2"></dependency>
+    <dependency ref="pkg:golang/gopkg.in/ini.v1@v1.51.1"></dependency>
+    <dependency ref="pkg:golang/gopkg.in/mgo.v2@v2.0.0-20180705113604-9856a29383ce"></dependency>
+    <dependency ref="pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7"></dependency>
+    <dependency ref="pkg:golang/gopkg.in/yaml.v2@v2.2.8"></dependency>
+    <dependency ref="pkg:golang/gopkg.in/yaml.v3@v3.0.0-20200313102051-9f266ea9e77c"></dependency>
+    <dependency ref="pkg:golang/github.com/ProtonMail/proton-bridge@v1.6.3">
+      <dependency ref="pkg:golang/github.com/0xAX/notificator@v0.0.0-20191016112426-3962a5ea8da1"></dependency>
+      <dependency ref="pkg:golang/github.com/Masterminds/semver/v3@v3.1.0"></dependency>
+      <dependency ref="pkg:golang/github.com/ProtonMail/go-autostart@v0.0.0-20181114175602-c5272053443a"></dependency>
+      <dependency ref="pkg:golang/github.com/ProtonMail/go-imap-id@v0.0.0-20190926060100-f94a56b9ecde"></dependency>
+      <dependency ref="pkg:golang/github.com/ProtonMail/go-rfc5322@v0.5.0"></dependency>
+      <dependency ref="pkg:golang/github.com/ProtonMail/go-vcard@v0.0.0-20180326232728-33aaa0a0c8a5"></dependency>
+      <dependency ref="pkg:golang/github.com/ProtonMail/gopenpgp/v2@v2.1.3"></dependency>
+      <dependency ref="pkg:golang/github.com/PuerkitoBio/goquery@v1.5.1"></dependency>
+      <dependency ref="pkg:golang/github.com/abiosoft/ishell@v2.0.0"></dependency>
+      <dependency ref="pkg:golang/github.com/abiosoft/readline@v0.0.0-20180607040430-155bce2042db"></dependency>
+      <dependency ref="pkg:golang/github.com/allan-simon/go-singleinstance@v0.0.0-20160830203053-79edcfdc2dfc"></dependency>
+      <dependency ref="pkg:golang/github.com/chzyer/logex@v1.1.10"></dependency>
+      <dependency ref="pkg:golang/github.com/chzyer/test@v0.0.0-20180213035817-a1ea475d72b1"></dependency>
+      <dependency ref="pkg:golang/github.com/cucumber/godog@v0.8.1"></dependency>
+      <dependency ref="pkg:golang/github.com/ProtonMail/docker-credential-helpers@v1.1.0"></dependency>
+      <dependency ref="pkg:golang/github.com/ProtonMail/go-imap@v0.0.0-20201228133358-4db68cea0cac"></dependency>
+      <dependency ref="pkg:golang/github.com/emersion/go-imap-appendlimit@v0.0.0-20190308131241-25671c986a6a"></dependency>
+      <dependency ref="pkg:golang/github.com/emersion/go-imap-idle@v0.0.0-20200601154248-f05f54664cc4"></dependency>
+      <dependency ref="pkg:golang/github.com/emersion/go-imap-move@v0.0.0-20190710073258-6e5a51a5b342"></dependency>
+      <dependency ref="pkg:golang/github.com/emersion/go-imap-quota@v0.0.0-20200423100218-dcfd1b7d2b41"></dependency>
+      <dependency ref="pkg:golang/github.com/emersion/go-imap-unselect@v0.0.0-20171113212723-b985794e5f26"></dependency>
+      <dependency ref="pkg:golang/github.com/emersion/go-mbox@v1.0.2"></dependency>
+      <dependency ref="pkg:golang/github.com/emersion/go-message@v0.12.1-0.20201221184100-40c3f864532b"></dependency>
+      <dependency ref="pkg:golang/github.com/emersion/go-sasl@v0.0.0-20200509203442-7bfe0ed36a21"></dependency>
+      <dependency ref="pkg:golang/github.com/emersion/go-smtp@v0.14.0"></dependency>
+      <dependency ref="pkg:golang/github.com/emersion/go-textwrapper@v0.0.0-20200911093747-65d896831594"></dependency>
+      <dependency ref="pkg:golang/github.com/emersion/go-vcard@v0.0.0-20190105225839-8856043f13c5"></dependency>
+      <dependency ref="pkg:golang/github.com/fatih/color@v1.9.0"></dependency>
+      <dependency ref="pkg:golang/github.com/flynn-archive/go-shlex@v0.0.0-20150515145356-3f9db97f8568"></dependency>
+      <dependency ref="pkg:golang/github.com/getsentry/sentry-go@v0.8.0"></dependency>
+      <dependency ref="pkg:golang/github.com/go-resty/resty/v2@v2.3.0"></dependency>
+      <dependency ref="pkg:golang/github.com/golang/mock@v1.4.4"></dependency>
+      <dependency ref="pkg:golang/github.com/google/go-cmp@v0.5.1"></dependency>
+      <dependency ref="pkg:golang/github.com/google/uuid@v1.1.1"></dependency>
+      <dependency ref="pkg:golang/github.com/gopherjs/gopherjs@v0.0.0-20190430165422-3e4dfb77656c"></dependency>
+      <dependency ref="pkg:golang/github.com/hashicorp/go-multierror@v1.1.0"></dependency>
+      <dependency ref="pkg:golang/github.com/ProtonMail/bcrypt@v0.0.0-20170924085257-7509ea014998"></dependency>
+      <dependency ref="pkg:golang/github.com/jaytaylor/html2text@v0.0.0-20200412013138-3577fbdbcff7"></dependency>
+      <dependency ref="pkg:golang/github.com/keybase/go-keychain@v0.0.0-20200502122510-cda31fe0c86d"></dependency>
+      <dependency ref="pkg:golang/github.com/logrusorgru/aurora@v2.0.3"></dependency>
+      <dependency ref="pkg:golang/github.com/mattn/go-runewidth@v0.0.9"></dependency>
+      <dependency ref="pkg:golang/github.com/miekg/dns@v1.1.30"></dependency>
+      <dependency ref="pkg:golang/github.com/nsf/jsondiff@v0.0.0-20200515183724-f29ed568f4ce"></dependency>
+      <dependency ref="pkg:golang/github.com/olekukonko/tablewriter@v0.0.4"></dependency>
+      <dependency ref="pkg:golang/github.com/pkg/errors@v0.9.1"></dependency>
+      <dependency ref="pkg:golang/github.com/sirupsen/logrus@v1.7.0"></dependency>
+      <dependency ref="pkg:golang/github.com/skratchdot/open-golang@v0.0.0-20200116055534-eef842397966"></dependency>
+      <dependency ref="pkg:golang/github.com/ssor/bom@v0.0.0-20170718123548-6386211fdfcf"></dependency>
+      <dependency ref="pkg:golang/github.com/stretchr/testify@v1.6.1"></dependency>
+      <dependency ref="pkg:golang/github.com/therecipe/qt@v0.0.0-20200701200531-7f61353ee73e"></dependency>
+      <dependency ref="pkg:golang/github.com/urfave/cli/v2@v2.2.0"></dependency>
+      <dependency ref="pkg:golang/github.com/vmihailenco/msgpack/v5@v5.1.3"></dependency>
+      <dependency ref="pkg:golang/go.etcd.io/bbolt@v1.3.5"></dependency>
+      <dependency ref="pkg:golang/github.com/ProtonMail/crypto@v0.0.0-20201112115411-41db4ea0dd1c"></dependency>
+      <dependency ref="pkg:golang/golang.org/x/net@v0.0.0-20200707034311-ab3426394381"></dependency>
+      <dependency ref="pkg:golang/golang.org/x/text@v0.3.5-0.20201125200606-c27b9fd57aec"></dependency>
+    </dependency>
+  </dependencies>
+</bom>

--- a/proton-bridge/proton-bridge-v1.6.3.bom.xml
+++ b/proton-bridge/proton-bridge-v1.6.3.bom.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.2" serialNumber="urn:uuid:05f17eff-5296-4a84-a16c-d572c5178b13" version="1">
+<bom xmlns="http://cyclonedx.org/schema/bom/1.2" serialNumber="urn:uuid:836dad65-9f24-40ee-8074-71433055a058" version="1">
   <metadata>
-    <timestamp>2021-05-16T15:46:37+02:00</timestamp>
+    <timestamp>2021-05-16T17:07:43+02:00</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
         <name>cyclonedx-gomod</name>
-        <version>v0.6.0</version>
+        <version>v0.6.1</version>
         <hashes>
-          <hash alg="MD5">d0517cb759962ccf9c41c8a12875a8f4</hash>
-          <hash alg="SHA-1">0a7059c2ba93d66a6f3b895ea446a74ab8cf24d0</hash>
-          <hash alg="SHA-256">d9695be77c111ebff786b384581b76ccbf4e8e4463969f6e6e22e9dd9a7ed465</hash>
-          <hash alg="SHA-512">9e6f27516614980c9a745574dcf755679efaacf5cf2beafaf1a5ad67ff99f568f811bbac65e9641f3f82c9da8066d28e5487f52f6b1fa179ec9a878e8a7d461d</hash>
+          <hash alg="MD5">a92d9f6145a94c2c7ad8489d84301eb9</hash>
+          <hash alg="SHA-1">a5af6c5ef3f21bf5425c680b64acf57cc6a90c69</hash>
+          <hash alg="SHA-256">dc215a651772356eca763d6fe77169379c1cc25c2bb89c7d6df2e2170c3972ab</hash>
+          <hash alg="SHA-512">387953ab509c31bf352693de9df617650c87494e607119bc284b91ba9a0a2d284a2e96946c272dc284c4370875412eea855bc30351faedd099dbdbed209e4636</hash>
         </hashes>
       </tool>
     </tools>
@@ -37,7 +37,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -58,12 +57,10 @@
       <licenses>
         <license>
           <id>CC0-1.0</id>
-          <name>Creative Commons Zero v1.0 Universal</name>
           <url>https://spdx.org/licenses/CC0-1.0.html</url>
         </license>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -84,7 +81,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -105,8 +101,10 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+        <license>
+          <name>GooglePatentClause</name>
         </license>
       </licenses>
       <purl>pkg:golang/github.com/BurntSushi/xgb@v0.0.0-20160522181843-27f122750802</purl>
@@ -126,7 +124,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -147,7 +144,6 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
-          <name>Apache License 2.0</name>
           <url>https://spdx.org/licenses/Apache-2.0.html</url>
         </license>
       </licenses>
@@ -168,7 +164,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -189,7 +184,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -210,7 +204,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -231,7 +224,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -252,7 +244,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -273,7 +264,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -294,7 +284,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -315,7 +304,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -336,7 +324,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -357,7 +344,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -378,7 +364,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -399,7 +384,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -420,7 +404,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -441,7 +424,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -462,7 +444,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -483,7 +464,6 @@
       <licenses>
         <license>
           <id>BSD-2-Clause</id>
-          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
           <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
         </license>
       </licenses>
@@ -504,12 +484,10 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -530,7 +508,6 @@
       <licenses>
         <license>
           <id>MPL-2.0</id>
-          <name>Mozilla Public License 2.0</name>
           <url>https://spdx.org/licenses/MPL-2.0.html</url>
         </license>
       </licenses>
@@ -551,7 +528,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -586,7 +562,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -607,7 +582,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -628,7 +602,6 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
-          <name>Apache License 2.0</name>
           <url>https://spdx.org/licenses/Apache-2.0.html</url>
         </license>
       </licenses>
@@ -649,7 +622,6 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
-          <name>Apache License 2.0</name>
           <url>https://spdx.org/licenses/Apache-2.0.html</url>
         </license>
       </licenses>
@@ -670,7 +642,6 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
-          <name>Apache License 2.0</name>
           <url>https://spdx.org/licenses/Apache-2.0.html</url>
         </license>
       </licenses>
@@ -691,7 +662,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -712,7 +682,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -733,7 +702,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -754,7 +722,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -775,7 +742,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -796,7 +762,6 @@
       <licenses>
         <license>
           <id>ISC</id>
-          <name>ISC License</name>
           <url>https://spdx.org/licenses/ISC.html</url>
         </license>
       </licenses>
@@ -817,7 +782,6 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
-          <name>Apache License 2.0</name>
           <url>https://spdx.org/licenses/Apache-2.0.html</url>
         </license>
       </licenses>
@@ -852,7 +816,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -887,7 +850,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -908,7 +870,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -943,7 +904,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -964,7 +924,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -985,7 +944,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -1006,7 +964,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -1027,7 +984,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -1048,7 +1004,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -1069,7 +1024,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -1090,7 +1044,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -1111,7 +1064,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -1132,7 +1084,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -1153,7 +1104,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -1174,7 +1124,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -1209,7 +1158,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -1230,7 +1178,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -1251,7 +1198,6 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
-          <name>Apache License 2.0</name>
           <url>https://spdx.org/licenses/Apache-2.0.html</url>
         </license>
       </licenses>
@@ -1272,7 +1218,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -1293,7 +1238,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -1314,7 +1258,6 @@
       <licenses>
         <license>
           <id>BSD-2-Clause</id>
-          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
           <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
         </license>
       </licenses>
@@ -1335,7 +1278,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -1356,7 +1298,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -1377,7 +1318,6 @@
       <licenses>
         <license>
           <id>BSD-2-Clause</id>
-          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
           <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
         </license>
       </licenses>
@@ -1398,7 +1338,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -1419,7 +1358,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -1440,7 +1378,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -1461,7 +1398,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -1482,7 +1418,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -1503,7 +1438,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -1524,7 +1458,6 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
-          <name>Apache License 2.0</name>
           <url>https://spdx.org/licenses/Apache-2.0.html</url>
         </license>
       </licenses>
@@ -1545,7 +1478,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -1566,7 +1498,6 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
-          <name>Apache License 2.0</name>
           <url>https://spdx.org/licenses/Apache-2.0.html</url>
         </license>
       </licenses>
@@ -1587,7 +1518,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -1608,7 +1538,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -1629,7 +1558,6 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
-          <name>Apache License 2.0</name>
           <url>https://spdx.org/licenses/Apache-2.0.html</url>
         </license>
       </licenses>
@@ -1650,7 +1578,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -1671,7 +1598,6 @@
       <licenses>
         <license>
           <id>BSD-2-Clause</id>
-          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
           <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
         </license>
       </licenses>
@@ -1692,7 +1618,6 @@
       <licenses>
         <license>
           <id>BSD-2-Clause</id>
-          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
           <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
         </license>
       </licenses>
@@ -1713,7 +1638,6 @@
       <licenses>
         <license>
           <id>MPL-2.0</id>
-          <name>Mozilla Public License 2.0</name>
           <url>https://spdx.org/licenses/MPL-2.0.html</url>
         </license>
       </licenses>
@@ -1734,7 +1658,6 @@
       <licenses>
         <license>
           <id>MPL-2.0</id>
-          <name>Mozilla Public License 2.0</name>
           <url>https://spdx.org/licenses/MPL-2.0.html</url>
         </license>
       </licenses>
@@ -1755,7 +1678,6 @@
       <licenses>
         <license>
           <id>MPL-2.0</id>
-          <name>Mozilla Public License 2.0</name>
           <url>https://spdx.org/licenses/MPL-2.0.html</url>
         </license>
       </licenses>
@@ -1776,7 +1698,6 @@
       <licenses>
         <license>
           <id>MPL-2.0</id>
-          <name>Mozilla Public License 2.0</name>
           <url>https://spdx.org/licenses/MPL-2.0.html</url>
         </license>
       </licenses>
@@ -1797,7 +1718,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -1818,7 +1738,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -1839,7 +1758,6 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
-          <name>Apache License 2.0</name>
           <url>https://spdx.org/licenses/Apache-2.0.html</url>
         </license>
       </licenses>
@@ -1860,7 +1778,6 @@
       <licenses>
         <license>
           <id>BSD-2-Clause</id>
-          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
           <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
         </license>
       </licenses>
@@ -1881,7 +1798,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -1902,7 +1818,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -1923,7 +1838,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -1958,7 +1872,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -1979,7 +1892,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2000,7 +1912,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2021,7 +1932,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2042,7 +1952,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2063,7 +1972,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -2084,7 +1992,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -2105,7 +2012,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2126,7 +2032,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -2147,7 +2052,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2168,7 +2072,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2189,7 +2092,6 @@
       <licenses>
         <license>
           <id>BSD-2-Clause</id>
-          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
           <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
         </license>
       </licenses>
@@ -2210,7 +2112,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -2231,7 +2132,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2252,7 +2152,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2273,7 +2172,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2294,7 +2192,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2315,7 +2212,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2336,7 +2232,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2357,7 +2252,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2378,7 +2272,6 @@
       <licenses>
         <license>
           <id>Unlicense</id>
-          <name>The Unlicense</name>
           <url>https://spdx.org/licenses/Unlicense.html</url>
         </license>
       </licenses>
@@ -2399,7 +2292,6 @@
       <licenses>
         <license>
           <id>BSD-2-Clause</id>
-          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
           <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
         </license>
       </licenses>
@@ -2420,7 +2312,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2441,7 +2332,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2462,7 +2352,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2483,7 +2372,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2518,7 +2406,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2539,7 +2426,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -2560,7 +2446,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -2581,7 +2466,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2602,7 +2486,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2623,7 +2506,6 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
-          <name>Apache License 2.0</name>
           <url>https://spdx.org/licenses/Apache-2.0.html</url>
         </license>
       </licenses>
@@ -2644,7 +2526,6 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
-          <name>Apache License 2.0</name>
           <url>https://spdx.org/licenses/Apache-2.0.html</url>
         </license>
       </licenses>
@@ -2665,7 +2546,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2686,7 +2566,6 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
-          <name>Apache License 2.0</name>
           <url>https://spdx.org/licenses/Apache-2.0.html</url>
         </license>
       </licenses>
@@ -2707,7 +2586,6 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
-          <name>Apache License 2.0</name>
           <url>https://spdx.org/licenses/Apache-2.0.html</url>
         </license>
       </licenses>
@@ -2728,7 +2606,6 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
-          <name>Apache License 2.0</name>
           <url>https://spdx.org/licenses/Apache-2.0.html</url>
         </license>
       </licenses>
@@ -2749,7 +2626,6 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
-          <name>Apache License 2.0</name>
           <url>https://spdx.org/licenses/Apache-2.0.html</url>
         </license>
       </licenses>
@@ -2770,7 +2646,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2791,7 +2666,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2812,7 +2686,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2833,7 +2706,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2854,7 +2726,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2875,7 +2746,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2896,7 +2766,6 @@
       <licenses>
         <license>
           <id>BSD-2-Clause</id>
-          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
           <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
         </license>
       </licenses>
@@ -2917,7 +2786,6 @@
       <licenses>
         <license>
           <id>BSD-2-Clause</id>
-          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
           <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
         </license>
       </licenses>
@@ -2938,7 +2806,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -2959,7 +2826,6 @@
       <licenses>
         <license>
           <id>BSD-2-Clause</id>
-          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
           <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
         </license>
       </licenses>
@@ -2980,7 +2846,6 @@
       <licenses>
         <license>
           <id>BSD-2-Clause</id>
-          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
           <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
         </license>
       </licenses>
@@ -3001,7 +2866,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -3022,7 +2886,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -3043,7 +2906,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -3064,7 +2926,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -3085,7 +2946,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -3106,7 +2966,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -3127,7 +2986,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -3148,7 +3006,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -3169,7 +3026,6 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
-          <name>Apache License 2.0</name>
           <url>https://spdx.org/licenses/Apache-2.0.html</url>
         </license>
       </licenses>
@@ -3190,7 +3046,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -3211,7 +3066,6 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
-          <name>Apache License 2.0</name>
           <url>https://spdx.org/licenses/Apache-2.0.html</url>
         </license>
       </licenses>
@@ -3232,7 +3086,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -3253,7 +3106,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -3274,7 +3126,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -3295,7 +3146,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -3316,7 +3166,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -3337,7 +3186,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -3358,7 +3206,6 @@
       <licenses>
         <license>
           <id>LGPL-3.0</id>
-          <name>GNU Lesser General Public License v3.0 only</name>
           <url>https://spdx.org/licenses/LGPL-3.0.html</url>
         </license>
       </licenses>
@@ -3379,7 +3226,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -3400,7 +3246,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -3421,7 +3266,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -3442,7 +3286,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -3463,7 +3306,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -3484,7 +3326,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -3505,7 +3346,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -3526,7 +3366,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -3547,7 +3386,6 @@
       <licenses>
         <license>
           <id>BSD-2-Clause</id>
-          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
           <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
         </license>
       </licenses>
@@ -3568,7 +3406,6 @@
       <licenses>
         <license>
           <id>BSD-2-Clause</id>
-          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
           <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
         </license>
       </licenses>
@@ -3589,7 +3426,6 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
-          <name>Apache License 2.0</name>
           <url>https://spdx.org/licenses/Apache-2.0.html</url>
         </license>
       </licenses>
@@ -3610,7 +3446,6 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
-          <name>Apache License 2.0</name>
           <url>https://spdx.org/licenses/Apache-2.0.html</url>
         </license>
       </licenses>
@@ -3631,7 +3466,6 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
-          <name>Apache License 2.0</name>
           <url>https://spdx.org/licenses/Apache-2.0.html</url>
         </license>
       </licenses>
@@ -3652,7 +3486,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -3673,7 +3506,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -3694,7 +3526,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -3715,7 +3546,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -3750,7 +3580,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -3766,7 +3595,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -3787,7 +3615,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -3803,7 +3630,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -3819,7 +3645,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -3835,7 +3660,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -3851,7 +3675,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -3867,7 +3690,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -3883,7 +3705,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -3899,7 +3720,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -3915,7 +3735,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -3931,7 +3750,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -3947,7 +3765,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -3963,7 +3780,6 @@
       <licenses>
         <license>
           <id>BSD-2-Clause</id>
-          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
           <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
         </license>
       </licenses>
@@ -3984,7 +3800,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -4005,7 +3820,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -4026,7 +3840,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -4047,7 +3860,6 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
-          <name>Apache License 2.0</name>
           <url>https://spdx.org/licenses/Apache-2.0.html</url>
         </license>
       </licenses>
@@ -4068,7 +3880,6 @@
       <licenses>
         <license>
           <id>BSD-2-Clause</id>
-          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
           <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
         </license>
       </licenses>
@@ -4089,7 +3900,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -4110,7 +3920,6 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
-          <name>Apache License 2.0</name>
           <url>https://spdx.org/licenses/Apache-2.0.html</url>
         </license>
       </licenses>
@@ -4131,12 +3940,10 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
-          <name>Apache License 2.0</name>
           <url>https://spdx.org/licenses/Apache-2.0.html</url>
         </license>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>

--- a/proton-bridge/proton-bridge-v1.8.0.bom.json
+++ b/proton-bridge/proton-bridge-v1.8.0.bom.json
@@ -1,41 +1,41 @@
 {
   "bomFormat": "CycloneDX",
   "specVersion": "1.2",
-  "serialNumber": "urn:uuid:6eb3fb07-a708-47b1-b7d9-9401060d825b",
+  "serialNumber": "urn:uuid:eb9ad243-780f-4172-8036-008c6d1e4a76",
   "version": 1,
   "metadata": {
-    "timestamp": "2021-04-01T21:11:46+02:00",
+    "timestamp": "2021-05-16T15:43:42+02:00",
     "tools": [
       {
         "vendor": "CycloneDX",
         "name": "cyclonedx-gomod",
-        "version": "v0.3.0",
+        "version": "v0.6.0",
         "hashes": [
           {
             "alg": "MD5",
-            "content": "4ef5ffbaf5aefe235e0bf1975a522868"
+            "content": "d0517cb759962ccf9c41c8a12875a8f4"
           },
           {
             "alg": "SHA-1",
-            "content": "1606bc722340cadabdb8f765e47b66a3bb361cea"
+            "content": "0a7059c2ba93d66a6f3b895ea446a74ab8cf24d0"
           },
           {
             "alg": "SHA-256",
-            "content": "409a8557fd9d1e3a4c46b0fa9253ec4d678ce0b21f6e970debb7c513eaf2db5f"
+            "content": "d9695be77c111ebff786b384581b76ccbf4e8e4463969f6e6e22e9dd9a7ed465"
           },
           {
             "alg": "SHA-512",
-            "content": "381675723761dab7f60781df57953844ae9f637d57f073031fbe609c11c0451a7579f0b5675f5d62e5028e30eae0c0555e8089ce852bf3b3524096b28e1a819f"
+            "content": "9e6f27516614980c9a745574dcf755679efaacf5cf2beafaf1a5ad67ff99f568f811bbac65e9641f3f82c9da8066d28e5487f52f6b1fa179ec9a878e8a7d461d"
           }
         ]
       }
     ],
     "component": {
-      "bom-ref": "pkg:golang/github.com/ProtonMail/proton-bridge@v1.6.3",
+      "bom-ref": "pkg:golang/github.com/ProtonMail/proton-bridge@v1.8.0",
       "type": "application",
       "name": "github.com/ProtonMail/proton-bridge",
-      "version": "v1.6.3",
-      "purl": "pkg:golang/github.com/ProtonMail/proton-bridge@v1.6.3",
+      "version": "v1.8.0",
+      "purl": "pkg:golang/github.com/ProtonMail/proton-bridge@v1.8.0",
       "externalReferences": [
         {
           "url": "https://github.com/ProtonMail/proton-bridge",
@@ -55,6 +55,15 @@
         {
           "alg": "SHA-256",
           "content": "8fd1da69f6a90db3db1910e4bba7bf1d1b3a28131c287896726d7ff526f19e5e"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/0xAX/notificator@v0.0.0-20191016112426-3962a5ea8da1",
@@ -77,6 +86,22 @@
           "content": "1c3f20036b6407284c03061a1405fdc3697bbf1bc143934ca310eb921aa1b67e"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "CC0-1.0",
+            "name": "Creative Commons Zero v1.0 Universal",
+            "url": "https://spdx.org/licenses/CC0-1.0.html"
+          }
+        },
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/AndreasBriese/bbloom@v0.0.0-20190306092124-e2d15f34fcf9",
       "externalReferences": [
         {
@@ -95,6 +120,15 @@
         {
           "alg": "SHA-256",
           "content": "597918625e98af7a817f52bbf440672f899a9343a29817c1d1751ff55976f0e4"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/BurntSushi/toml@v0.3.1",
@@ -117,6 +151,15 @@
           "content": "d410d3cf4bbd9c2dfffe938231d347f828972556098795103423811bb8db10b7"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/BurntSushi/xgb@v0.0.0-20160522181843-27f122750802",
       "externalReferences": [
         {
@@ -135,6 +178,15 @@
         {
           "alg": "SHA-256",
           "content": "b11fbff186f8b25b6d078bc3f9bf5bb551275a02f7434d0e053cd54fc07d0b47"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/CloudyKit/fastprinter@v0.0.0-20200109182630-33d98a066a53",
@@ -157,6 +209,15 @@
           "content": "d4fc0ee70e550ad954525f8a4ce06c4c66658635a47326ec19a01abb9dad3b2f"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "name": "Apache License 2.0",
+            "url": "https://spdx.org/licenses/Apache-2.0.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/CloudyKit/jet/v3@v3.0.0",
       "externalReferences": [
         {
@@ -175,6 +236,15 @@
         {
           "alg": "SHA-256",
           "content": "eb9fa2b8961d457bff5f237ad82d6e12698ec77e37dab346feb2a55fa57b2a47"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/Joker/hpp@v1.0.0",
@@ -197,6 +267,15 @@
           "content": "6369540ec14a5514981a88cb275c8bc525dd3263184d896cd2b0afa2a98c5109"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/Masterminds/semver/v3@v3.1.0",
       "externalReferences": [
         {
@@ -215,6 +294,15 @@
         {
           "alg": "SHA-256",
           "content": "7d72b62ac7e790157d361fbd48acc7721623b84f6cd2f236d091b599bb4401c7"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/ProtonMail/go-autostart@v0.0.0-20181114175602-c5272053443a",
@@ -237,6 +325,15 @@
           "content": "a509232442c76b25b9f63a7baf81b90e59a789caf931c7a30dfc2c8dcc08d525"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/ProtonMail/go-crypto@v0.0.0-20201208171014-cdb7591792e2",
       "externalReferences": [
         {
@@ -255,6 +352,15 @@
         {
           "alg": "SHA-256",
           "content": "e64a10a334c310bca660ec856d0fd54ae6dec40117cc347ca8633998ef0645dc"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/ProtonMail/go-imap-id@v0.0.0-20190926060100-f94a56b9ecde",
@@ -277,6 +383,15 @@
           "content": "5ba46b80dfec4f18359acab31456fe1bcd0c166a63330eb5214fac966fb0967e"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/ProtonMail/go-mime@v0.0.0-20190923161245-9b5a4261663a",
       "externalReferences": [
         {
@@ -295,6 +410,15 @@
         {
           "alg": "SHA-256",
           "content": "2db2968e07efba66190abf01806c93524dc44c69052c08d0764b9252967909c1"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/ProtonMail/go-rfc5322@v0.5.0",
@@ -317,6 +441,15 @@
           "content": "5206b50c714de06531b8342bd05ef5b698bc23d1ea3c8959a1d640235951e954"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/ProtonMail/go-vcard@v0.0.0-20180326232728-33aaa0a0c8a5",
       "externalReferences": [
         {
@@ -335,6 +468,15 @@
         {
           "alg": "SHA-256",
           "content": "e3e9c50c9f56b5c5104e2a7f8ded8b9773f6d57840525e1ab16b1a7cbaf0f7b7"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/ProtonMail/gopenpgp/v2@v2.1.3",
@@ -357,6 +499,15 @@
           "content": "3d23c11a77bc348516c3effbbc5055fa41b627fe4c3a36f373bd79e0e68a0921"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/PuerkitoBio/goquery@v1.5.1",
       "externalReferences": [
         {
@@ -375,6 +526,15 @@
         {
           "alg": "SHA-256",
           "content": "5830bac92a49cdbc4658587868cc45142dbcc301a9e6912ea13b6f038abfa90e"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/Shopify/goreferrer@v0.0.0-20181106222321-ec9c9a553398",
@@ -397,6 +557,15 @@
           "content": "8d07f1eba8739e5600b70cc656d8505a7d052643c1f03240f3d56c500f47b876"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/abiosoft/ishell@v2.0.0",
       "externalReferences": [
         {
@@ -415,6 +584,15 @@
         {
           "alg": "SHA-256",
           "content": "0a33d44973a2629b4b6d376bd5171eb9981214343b535e484c44541ab50e471f"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/abiosoft/readline@v0.0.0-20180607040430-155bce2042db",
@@ -437,6 +615,15 @@
           "content": "b7d73bbfc2542aefd7c4e181534ca336968c968c4610985492a151ab489b19e5"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/ajg/form@v1.5.1",
       "externalReferences": [
         {
@@ -455,6 +642,15 @@
         {
           "alg": "SHA-256",
           "content": "99971ad3f1d9fd75973fdb7191f765d861fa994cc1a80972273deee4b83c7ee0"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/allan-simon/go-singleinstance@v0.0.0-20160830203053-79edcfdc2dfc",
@@ -477,6 +673,15 @@
           "content": "06eb8eeac49f40d151bb52e9a606c3db91ebdaf2d85b6e49bf11ece73cec2d3a"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-2-Clause",
+            "name": "BSD 2-Clause \"Simplified\" License",
+            "url": "https://spdx.org/licenses/BSD-2-Clause.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/andybalholm/cascadia@v1.1.0",
       "externalReferences": [
         {
@@ -495,6 +700,22 @@
         {
           "alg": "SHA-256",
           "content": "8ff0b69313dfc84d1df3bfe08008c8b0257909d92a9a36fe3b45bc5bed49f886"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        },
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/antlr/antlr4@v0.0.0-20201029161626-9a95f0cc3d7c",
@@ -517,6 +738,15 @@
           "content": "1b56cfbdc8b037217b21498a5cdb7d024de6eaef43135ac5f919ad22406955d0"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MPL-2.0",
+            "name": "Mozilla Public License 2.0",
+            "url": "https://spdx.org/licenses/MPL-2.0.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/armon/consul-api@v0.0.0-20180202201655-eb2c6b5be1b6",
       "externalReferences": [
         {
@@ -535,6 +765,15 @@
         {
           "alg": "SHA-256",
           "content": "901a7783930a0426984323b3db44d35643a9cadacc01a92f2fb43fcf530b35cf"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/aymerick/raymond@v2.0.3-0.20180322193309-b565731e1464",
@@ -577,6 +816,15 @@
           "content": "abbeb7a9ff61b8dd7590341abd6b2865724d5b7c44138249c876b9436e7fb1df"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/chzyer/test@v0.0.0-20180213035817-a1ea475d72b1",
       "externalReferences": [
         {
@@ -595,6 +843,15 @@
         {
           "alg": "SHA-256",
           "content": "b033269beabfdfe06e91d229c703b7eb9bff45bb29a7636de579ed810457abc4"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/codegangsta/inject@v0.0.0-20150114235600-33e0aa1cb7c0",
@@ -617,6 +874,15 @@
           "content": "a1d778f324614e5305c1bc3b560cea519671ae74a7f543baf8f691436c8a04d6"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "name": "Apache License 2.0",
+            "url": "https://spdx.org/licenses/Apache-2.0.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/coreos/etcd@v3.3.10",
       "externalReferences": [
         {
@@ -635,6 +901,15 @@
         {
           "alg": "SHA-256",
           "content": "59a79e10ff2bd1332fc3a102b612acc787b325fc00354abbba215db513c291c5"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "name": "Apache License 2.0",
+            "url": "https://spdx.org/licenses/Apache-2.0.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/coreos/go-etcd@v2.0.0",
@@ -657,6 +932,15 @@
           "content": "dc99b7b4b9ac80061c8c2fb8529ee126b1413ebfa7eeb02a61e4b0fd265acee6"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "name": "Apache License 2.0",
+            "url": "https://spdx.org/licenses/Apache-2.0.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/coreos/go-semver@v0.2.0",
       "externalReferences": [
         {
@@ -675,6 +959,15 @@
         {
           "alg": "SHA-256",
           "content": "05228c3656310ef9ee9e54f29aab6038d8cd9da455d6c4e9728bf0c23176da39"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/cpuguy83/go-md2man@v1.0.10",
@@ -697,6 +990,15 @@
           "content": "53eb3dd144d2620a6d64cc10876691af72ee6b32c921af8f83729cd729526156"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/cpuguy83/go-md2man/v2@v2.0.0-20190314233015-f79a8a8ca69d",
       "externalReferences": [
         {
@@ -715,6 +1017,15 @@
         {
           "alg": "SHA-256",
           "content": "b8399a1b371d8e11788bfa65823984b2b887d75634a3b44a6a911ffcb0da337c"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/creack/pty@v1.1.9",
@@ -737,6 +1048,15 @@
           "content": "9556fe5f8d48e180eb784fa26d9e746dd5e6c92c6046f898160298e80c385c4f"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/cucumber/godog@v0.8.1",
       "externalReferences": [
         {
@@ -755,6 +1075,15 @@
         {
           "alg": "SHA-256",
           "content": "dd135c129060e088480a165d15149d950b754230a9d6c3003c8ace9e6ed87fc8"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/danieljoos/wincred@v1.1.0",
@@ -777,6 +1106,15 @@
           "content": "be3f63feed5baa7bc211f24ec1486d94e011aacdfeae41d8635de36164d4f7b7"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "ISC",
+            "name": "ISC License",
+            "url": "https://spdx.org/licenses/ISC.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
       "externalReferences": [
         {
@@ -795,6 +1133,15 @@
         {
           "alg": "SHA-256",
           "content": "0ec8711716565d470ed315f8efa5490b4ed7b2be990815511ca67ddce87b12fa"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "name": "Apache License 2.0",
+            "url": "https://spdx.org/licenses/Apache-2.0.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/dgraph-io/badger@v1.6.0",
@@ -837,6 +1184,15 @@
           "content": "b5d9590a967f3fd0e17330934a2c6020a9b03efebec0fe431a3a8b630e525220"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/dgryski/go-farm@v0.0.0-20190423205320-6a90982ecee2",
       "externalReferences": [
         {
@@ -877,6 +1233,15 @@
           "content": "5529d3b180a79451da336fe280ed61e97dc703bd637286d0bb17a6824ab8cd8a"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/dustin/go-humanize@v1.0.0",
       "externalReferences": [
         {
@@ -895,6 +1260,15 @@
         {
           "alg": "SHA-256",
           "content": "7250b59570697b69138f654775a22ef5a8d941ee2470463d8f436c9c30c1677a"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/eknkc/amber@v0.0.0-20171010120322-cdade1c07385",
@@ -937,6 +1311,15 @@
           "content": "6cc7523e6eacb2cb8e16921abdebb75c60228cc4b74ead92dc4a8566667189d7"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/emersion/go-imap-appendlimit@v0.0.0-20190308131241-25671c986a6a",
       "externalReferences": [
         {
@@ -955,6 +1338,15 @@
         {
           "alg": "SHA-256",
           "content": "fc92002f398276e7f9a3c4d625288e0734dbf7e47448287012552b24b969da9a"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/emersion/go-imap-idle@v0.0.0-20200601154248-f05f54664cc4",
@@ -977,6 +1369,15 @@
           "content": "e69d6ddded4fa266202d6c04c21c0453991507073201c56b3a97b1bfc01e671d"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/emersion/go-imap-move@v0.0.0-20190710073258-6e5a51a5b342",
       "externalReferences": [
         {
@@ -986,18 +1387,27 @@
       ]
     },
     {
-      "bom-ref": "pkg:golang/github.com/emersion/go-imap-quota@v0.0.0-20200423100218-dcfd1b7d2b41",
+      "bom-ref": "pkg:golang/github.com/emersion/go-imap-quota@v0.0.0-20210203125329-619074823f3c",
       "type": "library",
       "name": "github.com/emersion/go-imap-quota",
-      "version": "v0.0.0-20200423100218-dcfd1b7d2b41",
+      "version": "v0.0.0-20210203125329-619074823f3c",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "cf99431a749445ab8110374d2e3de8d3e1e881560a40219e63702797fc7245f5"
+          "content": "92170476ed721626630608bb8069d088b8694a08212746139ca0f4978114aaa7"
         }
       ],
-      "purl": "pkg:golang/github.com/emersion/go-imap-quota@v0.0.0-20200423100218-dcfd1b7d2b41",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/emersion/go-imap-quota@v0.0.0-20210203125329-619074823f3c",
       "externalReferences": [
         {
           "url": "https://github.com/emersion/go-imap-quota",
@@ -1015,6 +1425,15 @@
         {
           "alg": "SHA-256",
           "content": "16249bf3e5c14104a4717dee6ebfb5b40b6544905868599166a380c1e67d5b2f"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/emersion/go-imap-unselect@v0.0.0-20171113212723-b985794e5f26",
@@ -1037,6 +1456,15 @@
           "content": "b44feb4fe944ba02bdcb49b21329820879f0959374e219573eb6ca9314410392"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/emersion/go-mbox@v1.0.2",
       "externalReferences": [
         {
@@ -1055,6 +1483,15 @@
         {
           "alg": "SHA-256",
           "content": "c58ba15ba7a04da08ffb38db51c7e8cbf0ebdc049d54f47d5bb7e6907bd91cf1"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/emersion/go-message@v0.12.1-0.20201221184100-40c3f864532b",
@@ -1077,6 +1514,15 @@
           "content": "389c9418c253cc74ddd57429f7c4136877ab9f1318cd168e6ac462afd8549454"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/emersion/go-sasl@v0.0.0-20200509203442-7bfe0ed36a21",
       "externalReferences": [
         {
@@ -1095,6 +1541,15 @@
         {
           "alg": "SHA-256",
           "content": "4585b6d37a7e11c3e32fc67f6694fd959ea239cf0c1b5310cc4c7550a1245e50"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/emersion/go-smtp@v0.14.0",
@@ -1117,6 +1572,15 @@
           "content": "21b141b70a13432c347c8339c6fd4717e63edd98a30d1f37f5632e960c427146"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/emersion/go-textwrapper@v0.0.0-20200911093747-65d896831594",
       "externalReferences": [
         {
@@ -1137,6 +1601,15 @@
           "content": "9fdab1f7cc624b9578c76588a4f0b6aebf6650ce6b8bdaff62108429b8421eba"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/emersion/go-vcard@v0.0.0-20190105225839-8856043f13c5",
       "externalReferences": [
         {
@@ -1155,6 +1628,15 @@
         {
           "alg": "SHA-256",
           "content": "812266c6bb37ecb813a91fe8c89056a24ea4e92bd71147ab1536e5b488579013"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/etcd-io/bbolt@v1.3.3",
@@ -1197,6 +1679,15 @@
           "content": "f313c7978fead55caa1883e27f517ed55dd8de54a6aead3511a6d45b70a85b9b"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/fatih/color@v1.9.0",
       "externalReferences": [
         {
@@ -1215,6 +1706,15 @@
         {
           "alg": "SHA-256",
           "content": "43b8ee0ccd10b5c9e10a97b22c640aca0e13388821b8d5eb90bdf6a47014331a"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/fatih/structs@v1.1.0",
@@ -1237,6 +1737,15 @@
           "content": "04c5d86115932ce24a961fa5381b7a9d44205c07c1ee854842de5c36b7aa48b2"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "name": "Apache License 2.0",
+            "url": "https://spdx.org/licenses/Apache-2.0.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/flynn-archive/go-shlex@v0.0.0-20150515145356-3f9db97f8568",
       "externalReferences": [
         {
@@ -1255,6 +1764,15 @@
         {
           "alg": "SHA-256",
           "content": "217b3e40b9a75d6d82717b98fbc333bff7d612c3c65b1a9e7cfb423f90a757d2"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7",
@@ -1277,6 +1795,15 @@
           "content": "d5a4f508239e746148054abbe0bc6698ac1c20fe4b3a3573988749e29b213db8"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/gavv/httpexpect@v2.0.0",
       "externalReferences": [
         {
@@ -1295,6 +1822,15 @@
         {
           "alg": "SHA-256",
           "content": "179d9c8c154bba24df756ea9e0916ec65b77a4e8ca7d6613fda91aedc749eefd"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-2-Clause",
+            "name": "BSD 2-Clause \"Simplified\" License",
+            "url": "https://spdx.org/licenses/BSD-2-Clause.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/getsentry/sentry-go@v0.8.0",
@@ -1317,6 +1853,15 @@
           "content": "b7c155930df72fec2295fd90896930d1457beea469707fc91cf286a4a6b613c8"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/gin-contrib/sse@v0.0.0-20190301062529-5545eab6dad3",
       "externalReferences": [
         {
@@ -1335,6 +1880,15 @@
         {
           "alg": "SHA-256",
           "content": "ded3280827ccee9a6ab11d29b73ff08b58a6a4da53efff7042d319f25af59824"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/gin-gonic/gin@v1.4.0",
@@ -1357,6 +1911,15 @@
           "content": "d2090fea6cda32a926a5c25808538b90807023bc451311b4ddb6e43a40af50f2"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-2-Clause",
+            "name": "BSD 2-Clause \"Simplified\" License",
+            "url": "https://spdx.org/licenses/BSD-2-Clause.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/go-check/check@v0.0.0-20180628173108-788fd7840127",
       "externalReferences": [
         {
@@ -1375,6 +1938,15 @@
         {
           "alg": "SHA-256",
           "content": "2d41f39a42b7194294acbff581f054c401f371ebf76a94257b35fff8eee66bac"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/go-errors/errors@v1.0.1",
@@ -1397,6 +1969,15 @@
           "content": "c6f78a5b3da26ae79e4da52075eb737a5f94edec728a00d806bcb255f57fad99"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/go-martini/martini@v0.0.0-20170121215854-22fa46961aab",
       "externalReferences": [
         {
@@ -1406,18 +1987,27 @@
       ]
     },
     {
-      "bom-ref": "pkg:golang/github.com/go-resty/resty/v2@v2.3.0",
+      "bom-ref": "pkg:golang/github.com/go-resty/resty/v2@v2.6.0",
       "type": "library",
       "name": "github.com/go-resty/resty/v2",
-      "version": "v2.3.0",
+      "version": "v2.6.0",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "24e39e02f8d295aa534fdda9f31892d7d6717afd677868a4a07b1725e3aaf12a"
+          "content": "8e8211e4f34b336105aaa11252308c197ad6997347114f421222bcd77a0a612e"
         }
       ],
-      "purl": "pkg:golang/github.com/go-resty/resty/v2@v2.3.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/go-resty/resty/v2@v2.6.0",
       "externalReferences": [
         {
           "url": "https://github.com/go-resty/resty/v2",
@@ -1435,6 +2025,15 @@
         {
           "alg": "SHA-256",
           "content": "b3edb528daa5a5e3df91a87623e8301c5f319895918e8a18fb9db8f24ea6e00d"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/gobwas/httphead@v0.0.0-20180130184737-2c6c146eadee",
@@ -1457,6 +2056,15 @@
           "content": "4049943a59d28d6b67a5118717749ab8488eb32f360aea7cdd57f62dc3259dcf"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/gobwas/pool@v0.2.0",
       "externalReferences": [
         {
@@ -1475,6 +2083,15 @@
         {
           "alg": "SHA-256",
           "content": "0a801abd6ff077f92e95f66648806dea9db89f88fbb4780d5428ec7c754d51ba"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/gobwas/ws@v1.0.2",
@@ -1497,6 +2114,15 @@
           "content": "97be425c6452c1b69836997f6765f55c82003120aabaf5e0a5564387010826c7"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "name": "Apache License 2.0",
+            "url": "https://spdx.org/licenses/Apache-2.0.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/golang/mock@v1.4.4",
       "externalReferences": [
         {
@@ -1515,6 +2141,15 @@
         {
           "alg": "SHA-256",
           "content": "605f3e7e50574b978ef36e93e27cea3ebc5f8504e18579746337ee50fbb84818"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/golang/protobuf@v1.3.1",
@@ -1537,6 +2172,15 @@
           "content": "cb45a686f9a5edc1a7ccf6bd9e8727fdf32b68c1ff94c0dd786fab931e158186"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "name": "Apache License 2.0",
+            "url": "https://spdx.org/licenses/Apache-2.0.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/gomodule/redigo@v1.7.1-0.20190724094224-574c33c3df38",
       "externalReferences": [
         {
@@ -1555,6 +2199,15 @@
         {
           "alg": "SHA-256",
           "content": "245ac51016f6c4ab9f83a5e426c26bf966ca6f8150954462e5151c06f798bbd9"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/google/go-cmp@v0.5.1",
@@ -1577,6 +2230,15 @@
           "content": "5e4c22fdad6b72f360d4f3d87b9bc8f066de058fe3ad5b835f9012b803564eb9"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/google/go-querystring@v1.0.0",
       "externalReferences": [
         {
@@ -1595,6 +2257,15 @@
         {
           "alg": "SHA-256",
           "content": "03c3de5b9f69c44f48a0546a069dfb53e99235a428678e85d5fd1ff3add7497c"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "name": "Apache License 2.0",
+            "url": "https://spdx.org/licenses/Apache-2.0.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/google/gofuzz@v1.0.0",
@@ -1617,6 +2288,15 @@
           "content": "1a46dcb21fc66e95f3ee53dfb4b0373fa4d83308c22d89bcde388541917fde06"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/google/uuid@v1.1.1",
       "externalReferences": [
         {
@@ -1635,6 +2315,15 @@
         {
           "alg": "SHA-256",
           "content": "ee517e573d0baa2462767cc2d4eabce9fa57d6afe212fd8a25dac2b6db588d3e"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-2-Clause",
+            "name": "BSD 2-Clause \"Simplified\" License",
+            "url": "https://spdx.org/licenses/BSD-2-Clause.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/gopherjs/gopherjs@v0.0.0-20190430165422-3e4dfb77656c",
@@ -1657,6 +2346,15 @@
           "content": "abb01e0c1a67064f00a20703e0349a83f524c3f295f988732e3d9b3f91ef2823"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-2-Clause",
+            "name": "BSD 2-Clause \"Simplified\" License",
+            "url": "https://spdx.org/licenses/BSD-2-Clause.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/gorilla/websocket@v1.4.1",
       "externalReferences": [
         {
@@ -1675,6 +2373,15 @@
         {
           "alg": "SHA-256",
           "content": "84baeab440e74727b7fac831eb3e2a54b36ebe21f7311e5a434ca43496bf5180"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MPL-2.0",
+            "name": "Mozilla Public License 2.0",
+            "url": "https://spdx.org/licenses/MPL-2.0.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/hashicorp/errwrap@v1.0.0",
@@ -1697,6 +2404,15 @@
           "content": "07d533c064097a19d4635c8dae7c111077377c66c2db179fa3c8384db12569c2"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MPL-2.0",
+            "name": "Mozilla Public License 2.0",
+            "url": "https://spdx.org/licenses/MPL-2.0.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/hashicorp/go-multierror@v1.1.0",
       "externalReferences": [
         {
@@ -1715,6 +2431,15 @@
         {
           "alg": "SHA-256",
           "content": "def35efdf585e4206044882e75ad6679686c647cb79bc802279c31f9d2335ff1"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MPL-2.0",
+            "name": "Mozilla Public License 2.0",
+            "url": "https://spdx.org/licenses/MPL-2.0.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/hashicorp/go-version@v1.2.0",
@@ -1737,6 +2462,15 @@
           "content": "d009e5ce3a62e2f11ab1378d167da62c98134b0b74fbab1fb224c6f2a7161b1e"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MPL-2.0",
+            "name": "Mozilla Public License 2.0",
+            "url": "https://spdx.org/licenses/MPL-2.0.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/hashicorp/hcl@v1.0.0",
       "externalReferences": [
         {
@@ -1755,6 +2489,15 @@
         {
           "alg": "SHA-256",
           "content": "9df08ebca61f92060ff21922ae12687174f6fb3383f3250d8d76967d397214a2"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/hpcloud/tail@v1.0.0",
@@ -1777,6 +2520,15 @@
           "content": "28888aaf45521b60945b5865d63a62caecee25e2945290bc88cd40204ecdd559"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/imkira/go-interpol@v1.1.0",
       "externalReferences": [
         {
@@ -1795,6 +2547,15 @@
         {
           "alg": "SHA-256",
           "content": "67cb6ee6cada2d709721c011c41a7ff1c6ef97055aed9d4d1e0f5710a86d4af3"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "name": "Apache License 2.0",
+            "url": "https://spdx.org/licenses/Apache-2.0.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/inconshreveable/mousetrap@v1.0.0",
@@ -1817,6 +2578,15 @@
           "content": "c5559ad5703151c00b9cbdf6a4f9ddf9523f0237c1fe0be6e7ba85a99b401409"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-2-Clause",
+            "name": "BSD 2-Clause \"Simplified\" License",
+            "url": "https://spdx.org/licenses/BSD-2-Clause.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/iris-contrib/blackfriday@v2.0.0",
       "externalReferences": [
         {
@@ -1835,6 +2605,15 @@
         {
           "alg": "SHA-256",
           "content": "9db9571d236874d6904bc950503b1018e05b5e904a360fc8e7e299ed6de635d1"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/iris-contrib/go.uuid@v2.0.0",
@@ -1857,6 +2636,15 @@
           "content": "a7b27fe74234723a34c2afd559508315df2d68f25bb850be6eadb74a7891157d"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/iris-contrib/jade@v1.1.3",
       "externalReferences": [
         {
@@ -1875,6 +2663,15 @@
         {
           "alg": "SHA-256",
           "content": "cc63fba56e75a22e5e41930894603723e14763dfc739058307ee7bdb28a7d2da"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/iris-contrib/pongo2@v0.0.1",
@@ -1917,6 +2714,15 @@
           "content": "613dae57042245067109a69a8707dc813ab68f78faeb0d349ffdbb81bff3b9bb"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/ProtonMail/bcrypt@v0.0.0-20170924085257-7509ea014998",
       "externalReferences": [
         {
@@ -1935,6 +2741,15 @@
         {
           "alg": "SHA-256",
           "content": "8347c01818ac1da110d1346ad6206f7a61517fef0011612604449289607756c7"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/jaytaylor/html2text@v0.0.0-20200412013138-3577fbdbcff7",
@@ -1957,6 +2772,15 @@
           "content": "f72cee77f1eddfaca0c1ab46c79e95c0266d948ff6003d794f55f6b234ae1a7b"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/json-iterator/go@v1.1.9",
       "externalReferences": [
         {
@@ -1975,6 +2799,15 @@
         {
           "alg": "SHA-256",
           "content": "0d61bff8c2de500d8311984d8f3cce613ec6aa4e2b4ecc63d11948dd914bf59f"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/jtolds/gls@v4.20.0",
@@ -1997,6 +2830,15 @@
           "content": "b82d507d29489e9405f8cd1aa3ae629a1c2a2a7cf7436cff77c3d6651310bc33"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/k0kubun/colorstring@v0.0.0-20150214042306-9440f1994b88",
       "externalReferences": [
         {
@@ -2015,6 +2857,15 @@
         {
           "alg": "SHA-256",
           "content": "bd10d1526c1a71ca3fa660409bc81e2e7f2b1c475cfbd678340af94a1ed31bfe"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/kataras/golog@v0.0.10",
@@ -2037,6 +2888,15 @@
           "content": "3b78096ac8e6ed9c69c704c7f2d02966cbdfdbbe2c712190014a4d7b8edcdfb5"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/kataras/iris/v12@v12.1.8",
       "externalReferences": [
         {
@@ -2055,6 +2915,15 @@
         {
           "alg": "SHA-256",
           "content": "a5d25a4ef506dcd41f78c6db54223c253d93e60a0f95dcb27d40763c97e1d41b"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/kataras/neffos@v0.0.14",
@@ -2077,6 +2946,15 @@
           "content": "e8d022fae3c9fd9ba277a9ab00a960a5b235d7fccafe5578076af159a24df7c6"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/kataras/pio@v0.0.2",
       "externalReferences": [
         {
@@ -2095,6 +2973,15 @@
         {
           "alg": "SHA-256",
           "content": "e0708e357e512e0572e86e11918395def28d7266bda76dfa2dd18e8a926c6851"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/kataras/sitemap@v0.0.5",
@@ -2117,6 +3004,15 @@
           "content": "8158e10427d51a5df6448068a0e00dcdfc3ed14a97f0753ec8f94cbfcbf2a5c8"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/keybase/go-keychain@v0.0.0-20200502122510-cda31fe0c86d",
       "externalReferences": [
         {
@@ -2135,6 +3031,15 @@
         {
           "alg": "SHA-256",
           "content": "93dac2aae702b0fa4128387d803c24dd4e3a4dc35dee3a4a6a179df491880866"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-2-Clause",
+            "name": "BSD 2-Clause \"Simplified\" License",
+            "url": "https://spdx.org/licenses/BSD-2-Clause.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/keybase/go.dbus@v0.0.0-20200324223359-a94be52c0b03",
@@ -2157,6 +3062,15 @@
           "content": "8585b580ff78254980841b49f8b373e4ccbe801a1b0f13d1d6256e2ae836e9a0"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/klauspost/compress@v1.9.7",
       "externalReferences": [
         {
@@ -2175,6 +3089,15 @@
         {
           "alg": "SHA-256",
           "content": "bc98be3bf9cc745b74bea9bc359048eb0cc02d6740d97f9e822d2880dcab0bfc"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/klauspost/cpuid@v1.2.1",
@@ -2197,6 +3120,15 @@
           "content": "0c1d7b6a0d7d92bc7d085b33e28dde9d3acf5f22170a5fb68825c7fda300a7db"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/konsorten/go-windows-terminal-sequences@v1.0.2",
       "externalReferences": [
         {
@@ -2215,6 +3147,15 @@
         {
           "alg": "SHA-256",
           "content": "2ff0b0374cdead90e644551aa523e2b64e9ff90dfed336b5ad093356e3223052"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/kr/pretty@v0.1.0",
@@ -2237,6 +3178,15 @@
           "content": "564a1723049ba01a6793df4efca15ab801082ee347bf90d514a64c04dfe0520c"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/kr/pty@v1.1.1",
       "externalReferences": [
         {
@@ -2255,6 +3205,15 @@
         {
           "alg": "SHA-256",
           "content": "e4dc7461ad19a98db2815dfae90cedbab1c8d7726af79029715689061a52f806"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/kr/text@v0.2.0",
@@ -2277,6 +3236,15 @@
           "content": "cf4059a00ad8e05a9da54125fb0947a78867affa1247a3139909aff0e1d2a30c"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/labstack/echo/v4@v4.1.11",
       "externalReferences": [
         {
@@ -2295,6 +3263,15 @@
         {
           "alg": "SHA-256",
           "content": "24478ed1bbdcefc3ca7721f19684ca885f010f9886ac7f13e8c49e1af4a0a1bd"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/labstack/gommon@v0.3.0",
@@ -2317,6 +3294,15 @@
           "content": "2dff73b09ee12bc6bd7e6adc7f970c0337de1439857bdb82bb555526f0382c32"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Unlicense",
+            "name": "The Unlicense",
+            "url": "https://spdx.org/licenses/Unlicense.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/logrusorgru/aurora@v2.0.3",
       "externalReferences": [
         {
@@ -2335,6 +3321,15 @@
         {
           "alg": "SHA-256",
           "content": "2cb8179ac85e5de46850e04e8edc0f40258862a33f2d4d5ac83b4378f7ab45c6"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-2-Clause",
+            "name": "BSD 2-Clause \"Simplified\" License",
+            "url": "https://spdx.org/licenses/BSD-2-Clause.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/magiconair/properties@v1.8.0",
@@ -2357,6 +3352,15 @@
           "content": "708c2fbf062c7bfd3ed429143d81f966f548606dc9ac82e640421b2ee6abd366"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/martinlindhe/base36@v1.1.0",
       "externalReferences": [
         {
@@ -2375,6 +3379,15 @@
         {
           "alg": "SHA-256",
           "content": "b276cf2c1f1f55f53d8b06dba37d133ed6cb473c16bba6894ba5e1e1e69abe20"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/mattn/go-colorable@v0.1.4",
@@ -2397,6 +3410,15 @@
           "content": "1713ce4c536a1a4b835068b71ffaa451b40ee198816b66eb2aae6bd25f1319e3"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/mattn/go-isatty@v0.0.11",
       "externalReferences": [
         {
@@ -2415,6 +3437,15 @@
         {
           "alg": "SHA-256",
           "content": "2e6f7de5fdeb7f176977a4d29ae5421d56ff421ba9b97958afcb0223f41d13ed"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/mattn/go-runewidth@v0.0.9",
@@ -2457,6 +3488,15 @@
           "content": "81a95b3c18c8c26c91120c0609f4043785fc9716c99ca058bab833f957dc4ad0"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/mediocregopher/radix/v3@v3.4.2",
       "externalReferences": [
         {
@@ -2477,6 +3517,15 @@
           "content": "e653df2d34c0bc06ed4b456a4fef78c8eb459c67d4598cb1d3e893a02dceb37b"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/microcosm-cc/bluemonday@v1.0.2",
       "externalReferences": [
         {
@@ -2486,18 +3535,27 @@
       ]
     },
     {
-      "bom-ref": "pkg:golang/github.com/miekg/dns@v1.1.30",
+      "bom-ref": "pkg:golang/github.com/miekg/dns@v1.1.41",
       "type": "library",
       "name": "github.com/miekg/dns",
-      "version": "v1.1.30",
+      "version": "v1.1.41",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "430c3a16c7859fc3d17f0d3b8ee7aa217aa8766d092a288ab8ad037974aa7f2a"
+          "content": "58cb33656246d179b36caf45126cc7d9355ca98cc57acbac488078d5bf0a1f16"
         }
       ],
-      "purl": "pkg:golang/github.com/miekg/dns@v1.1.30",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/miekg/dns@v1.1.41",
       "externalReferences": [
         {
           "url": "https://github.com/miekg/dns",
@@ -2515,6 +3573,15 @@
         {
           "alg": "SHA-256",
           "content": "96e905f738971710c53e4035becaf9ce97355ee3c39ffc059edab9986fb81346"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/mitchellh/go-homedir@v1.1.0",
@@ -2537,6 +3604,15 @@
           "content": "7e6358570aa749f07d99953a392d8ee86b1733ec1cb24643b8a433bcdd440de1"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/mitchellh/mapstructure@v1.1.2",
       "externalReferences": [
         {
@@ -2555,6 +3631,15 @@
         {
           "alg": "SHA-256",
           "content": "4d12da67d703ff0f0f561f779ec3d76b556b43a8e5c0be6837c975e1095c35f8"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "name": "Apache License 2.0",
+            "url": "https://spdx.org/licenses/Apache-2.0.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
@@ -2577,6 +3662,15 @@
           "content": "f5fe35dacfba4666172d665213355580f18aec2d8fa611e3e5126bbdfc7d0162"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "name": "Apache License 2.0",
+            "url": "https://spdx.org/licenses/Apache-2.0.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/modern-go/reflect2@v1.0.1",
       "externalReferences": [
         {
@@ -2595,6 +3689,15 @@
         {
           "alg": "SHA-256",
           "content": "751316a00b5bf9e3f13252e4ac26c0aa1e1394f1d7be8194490df6dfff596a1b"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/moul/http2curl@v1.0.0",
@@ -2617,6 +3720,15 @@
           "content": "c5d9f3c0511357efa335ce16d66c3ffea1722466f60013a899b9992504b8f90a"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "name": "Apache License 2.0",
+            "url": "https://spdx.org/licenses/Apache-2.0.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/nats-io/jwt@v0.3.0",
       "externalReferences": [
         {
@@ -2635,6 +3747,15 @@
         {
           "alg": "SHA-256",
           "content": "8a4dc76cb859d180012eda3b897f34a592cfc3fe9dc774fefbe3192702e732b4"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "name": "Apache License 2.0",
+            "url": "https://spdx.org/licenses/Apache-2.0.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/nats-io/nats.go@v1.9.1",
@@ -2657,6 +3778,15 @@
           "content": "a8c778fa944781daf59c00a5bbeda1ff66b91764e629c0b38c20dacd5811a17e"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "name": "Apache License 2.0",
+            "url": "https://spdx.org/licenses/Apache-2.0.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/nats-io/nkeys@v0.1.0",
       "externalReferences": [
         {
@@ -2675,6 +3805,15 @@
         {
           "alg": "SHA-256",
           "content": "e6203c0d3f15eeaf162b611272fda969d35afeb4c449cd4a7673f0e130b6a5ac"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "name": "Apache License 2.0",
+            "url": "https://spdx.org/licenses/Apache-2.0.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/nats-io/nuid@v1.0.1",
@@ -2697,6 +3836,15 @@
           "content": "7c3e7b11147826d12ab166df3e1bf80cc880a47ca58a22b9c424cd5523e2680b"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e",
       "externalReferences": [
         {
@@ -2715,6 +3863,15 @@
         {
           "alg": "SHA-256",
           "content": "44f7257e06b648426680c9b3da4f8c83b728c19f32bf84ebab0f54b096f2ef9f"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/nsf/jsondiff@v0.0.0-20200515183724-f29ed568f4ce",
@@ -2737,6 +3894,15 @@
           "content": "bc70ff6187b55a8968efc9281b6f7d7fb57f5404b4f1ce88a422e7f848dfff0f"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/olekukonko/tablewriter@v0.0.4",
       "externalReferences": [
         {
@@ -2755,6 +3921,15 @@
         {
           "alg": "SHA-256",
           "content": "3a8c5b8df5d5672a1dd5f99662123b484c9a0fc074d329cfdd3f83e468b21ce6"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/onsi/ginkgo@v1.10.3",
@@ -2777,6 +3952,15 @@
           "content": "2b48dc442c0d40cdef146875a6932d0e1ffeec0a49ae395d957f1f0348c34cb4"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/onsi/gomega@v1.7.1",
       "externalReferences": [
         {
@@ -2795,6 +3979,15 @@
         {
           "alg": "SHA-256",
           "content": "4f9ccc18c2fad56a7e16571b5a34434fbc80c6124d0223cf2ce1440aad7cd737"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/pelletier/go-toml@v1.2.0",
@@ -2817,6 +4010,15 @@
           "content": "945b9057fa1a50c19c0f6b6ab7ed3544e4a626cef9546d53a043a46486789c4e"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-2-Clause",
+            "name": "BSD 2-Clause \"Simplified\" License",
+            "url": "https://spdx.org/licenses/BSD-2-Clause.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/pingcap/errors@v0.11.4",
       "externalReferences": [
         {
@@ -2835,6 +4037,15 @@
         {
           "alg": "SHA-256",
           "content": "14404bc75cd2db5e28c298f2eeab017a2c5b51192e850030acae54c0b193c2de"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-2-Clause",
+            "name": "BSD 2-Clause \"Simplified\" License",
+            "url": "https://spdx.org/licenses/BSD-2-Clause.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/pkg/errors@v0.9.1",
@@ -2857,6 +4068,15 @@
           "content": "e030700c4d0d1b24280476cb4183f04943e808c591e41133224fdfd6565b0103"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
       "externalReferences": [
         {
@@ -2875,6 +4095,15 @@
         {
           "alg": "SHA-256",
           "content": "1f2bc2d0045f9d906a9d7c00045792647a4abc91c925f3f3f3518db9e2e3d28a"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-2-Clause",
+            "name": "BSD 2-Clause \"Simplified\" License",
+            "url": "https://spdx.org/licenses/BSD-2-Clause.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/russross/blackfriday@v1.5.2",
@@ -2897,6 +4126,15 @@
           "content": "94fa9502d7be1ee1cd7e127fd0b0bdf04496473f1a7f2f6d33fd112bc9bda3e4"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-2-Clause",
+            "name": "BSD 2-Clause \"Simplified\" License",
+            "url": "https://spdx.org/licenses/BSD-2-Clause.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/russross/blackfriday/v2@v2.0.1",
       "externalReferences": [
         {
@@ -2915,6 +4153,15 @@
         {
           "alg": "SHA-256",
           "content": "67857b6becfe4e5a74ee5af8b920af2a90025f5420b85484816ee0a21db5f62c"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/ryanuber/columnize@v2.1.0",
@@ -2937,6 +4184,15 @@
           "content": "d6b425d6e1e57fc2a49546fd9d947fef0b40c2f06cbeb01a05c45164bd84556a"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/schollz/closestmatch@v2.1.0",
       "externalReferences": [
         {
@@ -2955,6 +4211,15 @@
         {
           "alg": "SHA-256",
           "content": "2a971adea44daddb8d9ce41e6b305dd32b1a2ab509888b88487c688244fd44f4"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/sergi/go-diff@v1.0.0",
@@ -2977,6 +4242,15 @@
           "content": "3dd9a808eeb0bdbb3eef2ac9c8c391b78fc1998e486322704bf90e896c7c987a"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/shurcooL/sanitized_anchor_name@v1.0.0",
       "externalReferences": [
         {
@@ -2995,6 +4269,15 @@
         {
           "alg": "SHA-256",
           "content": "4a1ac3d54f69641d764d7d1c572d03b5e3e8087f7b2bc12d5fe9a0ed901152d3"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/sirupsen/logrus@v1.7.0",
@@ -3017,6 +4300,15 @@
           "content": "24802eab71047fd7206d4e80b463cae024c6dd97fa08a30da9fd0c1d38200140"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/skratchdot/open-golang@v0.0.0-20200116055534-eef842397966",
       "externalReferences": [
         {
@@ -3035,6 +4327,15 @@
         {
           "alg": "SHA-256",
           "content": "cc4f7290495643afcd6261dade3a66ff21e7238c52a1f3fe50fe92a631dc49e3"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/smartystreets/assertions@v0.0.0-20180927180507-b2de0cb4f26d",
@@ -3057,6 +4358,15 @@
           "content": "7efd14f0550830f35fd4bf659c72ef2e182272b2150a112477320a62a6cd0bdb"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/smartystreets/goconvey@v1.6.4",
       "externalReferences": [
         {
@@ -3075,6 +4385,15 @@
         {
           "alg": "SHA-256",
           "content": "9bcff3d6deff7f08f2b2341161b3f4443f9b50817ff2d2703dd119b08f370022"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "name": "Apache License 2.0",
+            "url": "https://spdx.org/licenses/Apache-2.0.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/spf13/afero@v1.1.2",
@@ -3097,6 +4416,15 @@
           "content": "a207adfff095384a057b0a90c70af4123e728f2827a8692f820484fe0077e50f"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/spf13/cast@v1.3.0",
       "externalReferences": [
         {
@@ -3115,6 +4443,15 @@
         {
           "alg": "SHA-256",
           "content": "7f407e2e42d7e83b66447d62b28340f554ed3542bd2bcc58776f0934d7cebffb"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "name": "Apache License 2.0",
+            "url": "https://spdx.org/licenses/Apache-2.0.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/spf13/cobra@v0.0.5",
@@ -3137,6 +4474,15 @@
           "content": "5c711dc81f8472f96a65a99233864e30695cf77b7a01cb0112ef46735be7ef29"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/spf13/jwalterweatherman@v1.0.0",
       "externalReferences": [
         {
@@ -3155,6 +4501,15 @@
         {
           "alg": "SHA-256",
           "content": "ccf013e821b2eb05de43b36d4e76937ab7ca3ac57a57a17c6a01d71626b30e48"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/spf13/pflag@v1.0.3",
@@ -3177,6 +4532,15 @@
           "content": "55416ac3929ca917fb8bbd063b35bb37e43bfa0c55064492aa25c1d76f894383"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/spf13/viper@v1.3.2",
       "externalReferences": [
         {
@@ -3195,6 +4559,15 @@
         {
           "alg": "SHA-256",
           "content": "a6f6d9d253345d63c1a942aa154f1c99abeca6f225f67ba5398c1dcba205451a"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/ssor/bom@v0.0.0-20170718123548-6386211fdfcf",
@@ -3217,6 +4590,15 @@
           "content": "1db8363627692c4f2f7840641194cbdc2be5914215cee53d8c3a6564ee78738f"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/stretchr/objx@v0.2.0",
       "externalReferences": [
         {
@@ -3235,6 +4617,15 @@
         {
           "alg": "SHA-256",
           "content": "8433ce1e6a4ea4fe3495250b72ac3b22b45bfeeef0e91a430bddfdf57ca835dd"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/stretchr/testify@v1.6.1",
@@ -3257,6 +4648,15 @@
           "content": "1b40d0fd3450cab1198ed2e52f07af163691886f1e782325abd59743638ed9b9"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "LGPL-3.0",
+            "name": "GNU Lesser General Public License v3.0 only",
+            "url": "https://spdx.org/licenses/LGPL-3.0.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/therecipe/qt@v0.0.0-20200701200531-7f61353ee73e",
       "externalReferences": [
         {
@@ -3275,6 +4675,15 @@
         {
           "alg": "SHA-256",
           "content": "ffaf20cb687ed6658caf0645783d644226a5752cc06f8df676da5e278da8bdda"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/ugorji/go@v1.1.7",
@@ -3297,6 +4706,15 @@
           "content": "d92bd0695675a2e62baca2b0a12936a7377803d7af94a25bf684cbf8e68b512b"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/ugorji/go/codec@v1.1.7",
       "externalReferences": [
         {
@@ -3315,6 +4733,15 @@
         {
           "alg": "SHA-256",
           "content": "2534e733ac0acdd03426aa1d77deba3158f8bd66dbaae67291e5f5b0a6ded82e"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/urfave/cli/v2@v2.2.0",
@@ -3337,6 +4764,15 @@
           "content": "9088a63a2b68ca9ab7e0aed31bb0d4689f64abf37839fbb08b5b23cf42a2a577"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/urfave/negroni@v1.0.0",
       "externalReferences": [
         {
@@ -3355,6 +4791,15 @@
         {
           "alg": "SHA-256",
           "content": "1aa0394c2ff4d36d58fdbf451b83a2f4caf7abb5d8c7a2a59736b014885c74fc"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/valyala/bytebufferpool@v1.0.0",
@@ -3377,6 +4822,15 @@
           "content": "b9617c9602a679a21ec1654fc22e0646ad8febe478e8881865dc56b4cf86b446"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/valyala/fasthttp@v1.6.0",
       "externalReferences": [
         {
@@ -3395,6 +4849,15 @@
         {
           "alg": "SHA-256",
           "content": "b58f422623e73177f5111986d84c8aee035477e73a44a183d087d4f167544b3f"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/valyala/fasttemplate@v1.0.1",
@@ -3417,6 +4880,15 @@
           "content": "d11e0d2c3443657e897268498178b91386fc5a0f388a16e650aa7f1af48f1337"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/valyala/tcplisten@v0.0.0-20161114210144-ceec8f93295a",
       "externalReferences": [
         {
@@ -3435,6 +4907,15 @@
         {
           "alg": "SHA-256",
           "content": "1700bd28f8f25bc3aa4d4a8cb7aad0c3dcb9d2f0367132d73ca09c04245b4208"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-2-Clause",
+            "name": "BSD 2-Clause \"Simplified\" License",
+            "url": "https://spdx.org/licenses/BSD-2-Clause.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/vmihailenco/msgpack/v5@v5.1.3",
@@ -3457,6 +4938,15 @@
           "content": "8278e856e07f9258c9e702021043a9c7df285cc58f2e3db61baed56ddd6a3ea7"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-2-Clause",
+            "name": "BSD 2-Clause \"Simplified\" License",
+            "url": "https://spdx.org/licenses/BSD-2-Clause.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/vmihailenco/tagparser@v0.1.2",
       "externalReferences": [
         {
@@ -3475,6 +4965,15 @@
         {
           "alg": "SHA-256",
           "content": "27d106a5c66d3f413fadaa2b08cc6514649306bb1295a0c67f78d4feabc01367"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "name": "Apache License 2.0",
+            "url": "https://spdx.org/licenses/Apache-2.0.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/xeipuuv/gojsonpointer@v0.0.0-20180127040702-4e3ac2762d5f",
@@ -3497,6 +4996,15 @@
           "content": "133256807a2fa27b7b36c723a40c57b0303c4bc04c62f7bc639fbb72e444ed1d"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "name": "Apache License 2.0",
+            "url": "https://spdx.org/licenses/Apache-2.0.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/xeipuuv/gojsonreference@v0.0.0-20180127040603-bd5ef7bd5415",
       "externalReferences": [
         {
@@ -3515,6 +5023,15 @@
         {
           "alg": "SHA-256",
           "content": "2e160946cf8be1f06d8d951fb92648286795bb4411cbc7b95e2ec3d7b53167be"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "name": "Apache License 2.0",
+            "url": "https://spdx.org/licenses/Apache-2.0.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/xeipuuv/gojsonschema@v1.2.0",
@@ -3537,6 +5054,15 @@
           "content": "112152770619be47abbb746d76b62e7b3b4a84e0424800334b819ffa4d2d128c"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/xordataexchange/crypt@v0.0.3-0.20170626215501-b2862e3d0a77",
       "externalReferences": [
         {
@@ -3555,6 +5081,15 @@
         {
           "alg": "SHA-256",
           "content": "e9f4614a380b0a44c3dc99c9c6f689e128fe4d86e5c3be7b6ea62065a3aae596"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/yalp/jsonpath@v0.0.0-20180802001716-5cc68e5049a0",
@@ -3577,6 +5112,15 @@
           "content": "dbb71b7ea5cb544275a3c23abf7cbd960f18766e7710aa875c038cc441a508e0"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/github.com/yudai/gojsondiff@v1.0.0",
       "externalReferences": [
         {
@@ -3595,6 +5139,15 @@
         {
           "alg": "SHA-256",
           "content": "047c9f2a5432a9bb05379a7721f9c451db96bdbf62b38dbcfe735be4bdd4d353"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/yudai/golcs@v0.0.0-20170316035057-ecda9a501e82",
@@ -3637,6 +5190,15 @@
           "content": "5c0cf1f608c26f44718fb128a9c0a53c3d5de590716499348dbba83c77a706dd"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/go.etcd.io/bbolt@v1.3.5"
     },
     {
@@ -3649,6 +5211,15 @@
         {
           "alg": "SHA-256",
           "content": "89a55b10e9ec9121a0707ed74161c6e953e2ac70d1a187be21d774fdd9789bc0"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
         }
       ],
       "purl": "pkg:golang/github.com/ProtonMail/crypto@v0.0.0-20201112115411-41db4ea0dd1c",
@@ -3671,6 +5242,15 @@
           "content": "7acb64d6094e9d255e27db5d11965ce6600c0d993994d24dc89e83beb0644c45"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/golang.org/x/exp@v0.0.0-20190731235908-ec7cb31e5a56"
     },
     {
@@ -3683,6 +5263,15 @@
         {
           "alg": "SHA-256",
           "content": "faa1291003e10d9d68d31ded1f365340302b9ce8b13b3183f475097dc83499be"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
         }
       ],
       "purl": "pkg:golang/golang.org/x/image@v0.0.0-20190802002840-cff245a6509b"
@@ -3699,6 +5288,15 @@
           "content": "39527a41050101eb01f026628ca0d2b175fbc5856d521ae463483031f6e2e29e"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/golang.org/x/mobile@v0.0.0-20200801112145-973feb4309de"
     },
     {
@@ -3713,63 +5311,108 @@
           "content": "78fb8d0bb3d9e8ee41ce03e7f5b65ac8445705d7d98d46285c47f90537c37e1f"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/golang.org/x/mod@v0.1.1-0.20191209134235-331c550502dd"
     },
     {
-      "bom-ref": "pkg:golang/golang.org/x/net@v0.0.0-20200707034311-ab3426394381",
+      "bom-ref": "pkg:golang/golang.org/x/net@v0.0.0-20210405180319-a5a99cb37ef4",
       "type": "library",
       "name": "golang.org/x/net",
-      "version": "v0.0.0-20200707034311-ab3426394381",
+      "version": "v0.0.0-20210405180319-a5a99cb37ef4",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "5576a4e48e9a1169805de42303e41267396036ba6af668dc7c37a6b9ec482ac5"
+          "content": "e2719a56ed10adb8d3fc02b63d12ee41f42e87a0c9bdefa910b86a4dd023df1d"
         }
       ],
-      "purl": "pkg:golang/golang.org/x/net@v0.0.0-20200707034311-ab3426394381"
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/golang.org/x/net@v0.0.0-20210405180319-a5a99cb37ef4"
     },
     {
-      "bom-ref": "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e",
+      "bom-ref": "pkg:golang/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c",
       "type": "library",
       "name": "golang.org/x/sync",
-      "version": "v0.0.0-20190911185100-cd5d95a43a6e",
+      "version": "v0.0.0-20210220032951-036812b2e83c",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "bdcc466a84ecee457c9b9369f6e50d4229f806b2ceb61815ef6e7637c57e1706"
+          "content": "e4ab25198c05a6484687e435e9bc0c3f770ea27b47f0539ea7bb4657ce98ed24"
         }
       ],
-      "purl": "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e"
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c"
     },
     {
-      "bom-ref": "pkg:golang/golang.org/x/sys@v0.0.0-20200323222414-85ca7c5b95cd",
+      "bom-ref": "pkg:golang/golang.org/x/sys@v0.0.0-20210330210617-4fbd30eecc44",
       "type": "library",
       "name": "golang.org/x/sys",
-      "version": "v0.0.0-20200323222414-85ca7c5b95cd",
+      "version": "v0.0.0-20210330210617-4fbd30eecc44",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "c619b0caf8b3b93802daacfb665325b8fdb4b96f82dd19b4143fd62c35fcf3ce"
+          "content": "0658b8d69225cd3cdfdca118d3a9fec67ccafc1112220db37b83e07e1fda23c7"
         }
       ],
-      "purl": "pkg:golang/golang.org/x/sys@v0.0.0-20200323222414-85ca7c5b95cd"
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/golang.org/x/sys@v0.0.0-20210330210617-4fbd30eecc44"
     },
     {
-      "bom-ref": "pkg:golang/golang.org/x/term@v0.0.0-20201117132131-f5c789dd3221",
+      "bom-ref": "pkg:golang/golang.org/x/term@v0.0.0-20201126162022-7de9c90e9dd1",
       "type": "library",
       "name": "golang.org/x/term",
-      "version": "v0.0.0-20201117132131-f5c789dd3221",
+      "version": "v0.0.0-20201126162022-7de9c90e9dd1",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "fd91dd6d5a5d47f8e4de0df4fdde3250bd0953d924b23f3e17f6e741454b1833"
+          "content": "bfe3acb16417fa14c7126381830c5d6712b8cc7ab7c8eb3c17d27b9a4d0f63c1"
         }
       ],
-      "purl": "pkg:golang/golang.org/x/term@v0.0.0-20201117132131-f5c789dd3221"
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
+      "purl": "pkg:golang/golang.org/x/term@v0.0.0-20201126162022-7de9c90e9dd1"
     },
     {
       "bom-ref": "pkg:golang/golang.org/x/text@v0.3.5-0.20201125200606-c27b9fd57aec",
@@ -3781,6 +5424,15 @@
         {
           "alg": "SHA-256",
           "content": "035a988e7789bb305967680807caddeb3adfaba97b4a810c27c12c4a294d2bf5"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
         }
       ],
       "purl": "pkg:golang/golang.org/x/text@v0.3.5-0.20201125200606-c27b9fd57aec"
@@ -3797,6 +5449,15 @@
           "content": "c811c7c7e5d9a972419ba13191edcded5f609e5b325f1a023c46f5c957a78df9"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/golang.org/x/tools@v0.0.0-20200117012304-6edc0a871e69"
     },
     {
@@ -3811,6 +5472,15 @@
           "content": "13b83ef46213ab4ee1a5fad1bbae885437b131a91fbf9d9e2d9d825c15a22abe"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/golang.org/x/xerrors@v0.0.0-20191204190536-9bdfabe68543"
     },
     {
@@ -3823,6 +5493,15 @@
         {
           "alg": "SHA-256",
           "content": "04bada1579e6adebf9953fb196296a707f172bdfe2d00b76c4a8d6938a7acec5"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-2-Clause",
+            "name": "BSD 2-Clause \"Simplified\" License",
+            "url": "https://spdx.org/licenses/BSD-2-Clause.html"
+          }
         }
       ],
       "purl": "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f",
@@ -3845,6 +5524,15 @@
           "content": "c4e1cb5d9c15bc8f6186cf9c2caab9f88e689cebb040b850c22bbadf1c651ece"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/gopkg.in/fsnotify.v1@v1.4.7",
       "externalReferences": [
         {
@@ -3863,6 +5551,15 @@
         {
           "alg": "SHA-256",
           "content": "c6862e25513b293f393d85ab37bdf4460b8840ed1e3f35517c531769d22b5d33"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
         }
       ],
       "purl": "pkg:golang/gopkg.in/go-playground/assert.v1@v1.2.1",
@@ -3885,6 +5582,15 @@
           "content": "9450780e8314e81eb6eb0f27cbbe8c57b557e96d951dcb76195388df182232b4"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/gopkg.in/go-playground/validator.v8@v8.18.2",
       "externalReferences": [
         {
@@ -3903,6 +5609,15 @@
         {
           "alg": "SHA-256",
           "content": "1b26e81ebe14a8c88b5326d88dddb6663408284244a60b4b5edb866d1db53a1a"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "name": "Apache License 2.0",
+            "url": "https://spdx.org/licenses/Apache-2.0.html"
+          }
         }
       ],
       "purl": "pkg:golang/gopkg.in/ini.v1@v1.51.1",
@@ -3925,6 +5640,15 @@
           "content": "c5c1168d586f6c3cbe9c73faee73c30e96d8ad8f882e57e7764e1b462a151da5"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-2-Clause",
+            "name": "BSD 2-Clause \"Simplified\" License",
+            "url": "https://spdx.org/licenses/BSD-2-Clause.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/gopkg.in/mgo.v2@v2.0.0-20180705113604-9856a29383ce",
       "externalReferences": [
         {
@@ -3943,6 +5667,15 @@
         {
           "alg": "SHA-256",
           "content": "b9118975c88e1da108af37b65bc43700a91ea4b4e1da13aba13edafbb7337dd4"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
         }
       ],
       "purl": "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7",
@@ -3965,6 +5698,15 @@
           "content": "a1b37565a809494188d0493f2c19ae8f848d2cf7c89f2dcab0a168a7145d8f5d"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "name": "Apache License 2.0",
+            "url": "https://spdx.org/licenses/Apache-2.0.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/gopkg.in/yaml.v2@v2.2.8",
       "externalReferences": [
         {
@@ -3985,34 +5727,27 @@
           "content": "7545301e4d90102a3feafa80e38aed859f227b641730d78a4531c2358da75efa"
         }
       ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "name": "Apache License 2.0",
+            "url": "https://spdx.org/licenses/Apache-2.0.html"
+          }
+        },
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License",
+            "url": "https://spdx.org/licenses/MIT.html"
+          }
+        }
+      ],
       "purl": "pkg:golang/gopkg.in/yaml.v3@v3.0.0-20200313102051-9f266ea9e77c",
       "externalReferences": [
         {
           "url": "https://github.com/go-yaml/yaml",
           "type": "vcs"
-        }
-      ]
-    },
-    {
-      "bom-ref": "pkg:golang/std@1.16.2",
-      "type": "library",
-      "name": "std",
-      "version": "1.16.2",
-      "description": "The Go standard library",
-      "scope": "required",
-      "purl": "pkg:golang/std@1.16.2",
-      "externalReferences": [
-        {
-          "url": "https://golang.org/pkg/",
-          "type": "documentation"
-        },
-        {
-          "url": "https://go.googlesource.com/go",
-          "type": "vcs"
-        },
-        {
-          "url": "https://golang.org/",
-          "type": "website"
         }
       ]
     }
@@ -4049,10 +5784,7 @@
       "ref": "pkg:golang/github.com/ProtonMail/go-autostart@v0.0.0-20181114175602-c5272053443a"
     },
     {
-      "ref": "pkg:golang/github.com/ProtonMail/go-crypto@v0.0.0-20201208171014-cdb7591792e2",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/term@v0.0.0-20201117132131-f5c789dd3221"
-      ]
+      "ref": "pkg:golang/github.com/ProtonMail/go-crypto@v0.0.0-20201208171014-cdb7591792e2"
     },
     {
       "ref": "pkg:golang/github.com/ProtonMail/go-imap-id@v0.0.0-20190926060100-f94a56b9ecde"
@@ -4197,7 +5929,7 @@
       "ref": "pkg:golang/github.com/emersion/go-imap-move@v0.0.0-20190710073258-6e5a51a5b342"
     },
     {
-      "ref": "pkg:golang/github.com/emersion/go-imap-quota@v0.0.0-20200423100218-dcfd1b7d2b41"
+      "ref": "pkg:golang/github.com/emersion/go-imap-quota@v0.0.0-20210203125329-619074823f3c"
     },
     {
       "ref": "pkg:golang/github.com/emersion/go-imap-unselect@v0.0.0-20171113212723-b985794e5f26"
@@ -4309,7 +6041,10 @@
       "ref": "pkg:golang/github.com/go-martini/martini@v0.0.0-20170121215854-22fa46961aab"
     },
     {
-      "ref": "pkg:golang/github.com/go-resty/resty/v2@v2.3.0"
+      "ref": "pkg:golang/github.com/go-resty/resty/v2@v2.6.0",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/net@v0.0.0-20210405180319-a5a99cb37ef4"
+      ]
     },
     {
       "ref": "pkg:golang/github.com/gobwas/httphead@v0.0.0-20180130184737-2c6c146eadee"
@@ -4467,8 +6202,7 @@
         "pkg:golang/github.com/gorilla/websocket@v1.4.1",
         "pkg:golang/github.com/iris-contrib/go.uuid@v2.0.0",
         "pkg:golang/github.com/mediocregopher/radix/v3@v3.4.2",
-        "pkg:golang/github.com/nats-io/nats.go@v1.9.1",
-        "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e"
+        "pkg:golang/github.com/nats-io/nats.go@v1.9.1"
       ]
     },
     {
@@ -4559,7 +6293,10 @@
       "ref": "pkg:golang/github.com/microcosm-cc/bluemonday@v1.0.2"
     },
     {
-      "ref": "pkg:golang/github.com/miekg/dns@v1.1.30"
+      "ref": "pkg:golang/github.com/miekg/dns@v1.1.41",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c"
+      ]
     },
     {
       "ref": "pkg:golang/github.com/mitchellh/go-homedir@v1.1.0"
@@ -4844,20 +6581,20 @@
       "ref": "pkg:golang/golang.org/x/mod@v0.1.1-0.20191209134235-331c550502dd"
     },
     {
-      "ref": "pkg:golang/golang.org/x/net@v0.0.0-20200707034311-ab3426394381",
+      "ref": "pkg:golang/golang.org/x/net@v0.0.0-20210405180319-a5a99cb37ef4",
       "dependsOn": [
-        "pkg:golang/github.com/ProtonMail/crypto@v0.0.0-20201112115411-41db4ea0dd1c",
-        "pkg:golang/golang.org/x/sys@v0.0.0-20200323222414-85ca7c5b95cd"
+        "pkg:golang/golang.org/x/sys@v0.0.0-20210330210617-4fbd30eecc44",
+        "pkg:golang/golang.org/x/term@v0.0.0-20201126162022-7de9c90e9dd1"
       ]
     },
     {
-      "ref": "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e"
+      "ref": "pkg:golang/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c"
     },
     {
-      "ref": "pkg:golang/golang.org/x/sys@v0.0.0-20200323222414-85ca7c5b95cd"
+      "ref": "pkg:golang/golang.org/x/sys@v0.0.0-20210330210617-4fbd30eecc44"
     },
     {
-      "ref": "pkg:golang/golang.org/x/term@v0.0.0-20201117132131-f5c789dd3221"
+      "ref": "pkg:golang/golang.org/x/term@v0.0.0-20201126162022-7de9c90e9dd1"
     },
     {
       "ref": "pkg:golang/golang.org/x/text@v0.3.5-0.20201125200606-c27b9fd57aec"
@@ -4896,7 +6633,7 @@
       "ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.0-20200313102051-9f266ea9e77c"
     },
     {
-      "ref": "pkg:golang/github.com/ProtonMail/proton-bridge@v1.6.3",
+      "ref": "pkg:golang/github.com/ProtonMail/proton-bridge@v1.8.0",
       "dependsOn": [
         "pkg:golang/github.com/0xAX/notificator@v0.0.0-20191016112426-3962a5ea8da1",
         "pkg:golang/github.com/Masterminds/semver/v3@v3.1.0",
@@ -4917,7 +6654,7 @@
         "pkg:golang/github.com/emersion/go-imap-appendlimit@v0.0.0-20190308131241-25671c986a6a",
         "pkg:golang/github.com/emersion/go-imap-idle@v0.0.0-20200601154248-f05f54664cc4",
         "pkg:golang/github.com/emersion/go-imap-move@v0.0.0-20190710073258-6e5a51a5b342",
-        "pkg:golang/github.com/emersion/go-imap-quota@v0.0.0-20200423100218-dcfd1b7d2b41",
+        "pkg:golang/github.com/emersion/go-imap-quota@v0.0.0-20210203125329-619074823f3c",
         "pkg:golang/github.com/emersion/go-imap-unselect@v0.0.0-20171113212723-b985794e5f26",
         "pkg:golang/github.com/emersion/go-mbox@v1.0.2",
         "pkg:golang/github.com/emersion/go-message@v0.12.1-0.20201221184100-40c3f864532b",
@@ -4928,7 +6665,7 @@
         "pkg:golang/github.com/fatih/color@v1.9.0",
         "pkg:golang/github.com/flynn-archive/go-shlex@v0.0.0-20150515145356-3f9db97f8568",
         "pkg:golang/github.com/getsentry/sentry-go@v0.8.0",
-        "pkg:golang/github.com/go-resty/resty/v2@v2.3.0",
+        "pkg:golang/github.com/go-resty/resty/v2@v2.6.0",
         "pkg:golang/github.com/golang/mock@v1.4.4",
         "pkg:golang/github.com/google/go-cmp@v0.5.1",
         "pkg:golang/github.com/google/uuid@v1.1.1",
@@ -4939,7 +6676,7 @@
         "pkg:golang/github.com/keybase/go-keychain@v0.0.0-20200502122510-cda31fe0c86d",
         "pkg:golang/github.com/logrusorgru/aurora@v2.0.3",
         "pkg:golang/github.com/mattn/go-runewidth@v0.0.9",
-        "pkg:golang/github.com/miekg/dns@v1.1.30",
+        "pkg:golang/github.com/miekg/dns@v1.1.41",
         "pkg:golang/github.com/nsf/jsondiff@v0.0.0-20200515183724-f29ed568f4ce",
         "pkg:golang/github.com/olekukonko/tablewriter@v0.0.4",
         "pkg:golang/github.com/pkg/errors@v0.9.1",
@@ -4952,13 +6689,9 @@
         "pkg:golang/github.com/vmihailenco/msgpack/v5@v5.1.3",
         "pkg:golang/go.etcd.io/bbolt@v1.3.5",
         "pkg:golang/github.com/ProtonMail/crypto@v0.0.0-20201112115411-41db4ea0dd1c",
-        "pkg:golang/golang.org/x/net@v0.0.0-20200707034311-ab3426394381",
-        "pkg:golang/golang.org/x/text@v0.3.5-0.20201125200606-c27b9fd57aec",
-        "pkg:golang/std@1.16.2"
+        "pkg:golang/golang.org/x/net@v0.0.0-20210405180319-a5a99cb37ef4",
+        "pkg:golang/golang.org/x/text@v0.3.5-0.20201125200606-c27b9fd57aec"
       ]
-    },
-    {
-      "ref": "pkg:golang/std@1.16.2"
     }
   ]
 }

--- a/proton-bridge/proton-bridge-v1.8.0.bom.json
+++ b/proton-bridge/proton-bridge-v1.8.0.bom.json
@@ -1,31 +1,31 @@
 {
   "bomFormat": "CycloneDX",
   "specVersion": "1.2",
-  "serialNumber": "urn:uuid:eb9ad243-780f-4172-8036-008c6d1e4a76",
+  "serialNumber": "urn:uuid:d7a0ac67-e0f8-4342-86c6-801a02437636",
   "version": 1,
   "metadata": {
-    "timestamp": "2021-05-16T15:43:42+02:00",
+    "timestamp": "2021-05-16T17:10:53+02:00",
     "tools": [
       {
         "vendor": "CycloneDX",
         "name": "cyclonedx-gomod",
-        "version": "v0.6.0",
+        "version": "v0.6.1",
         "hashes": [
           {
             "alg": "MD5",
-            "content": "d0517cb759962ccf9c41c8a12875a8f4"
+            "content": "a92d9f6145a94c2c7ad8489d84301eb9"
           },
           {
             "alg": "SHA-1",
-            "content": "0a7059c2ba93d66a6f3b895ea446a74ab8cf24d0"
+            "content": "a5af6c5ef3f21bf5425c680b64acf57cc6a90c69"
           },
           {
             "alg": "SHA-256",
-            "content": "d9695be77c111ebff786b384581b76ccbf4e8e4463969f6e6e22e9dd9a7ed465"
+            "content": "dc215a651772356eca763d6fe77169379c1cc25c2bb89c7d6df2e2170c3972ab"
           },
           {
             "alg": "SHA-512",
-            "content": "9e6f27516614980c9a745574dcf755679efaacf5cf2beafaf1a5ad67ff99f568f811bbac65e9641f3f82c9da8066d28e5487f52f6b1fa179ec9a878e8a7d461d"
+            "content": "387953ab509c31bf352693de9df617650c87494e607119bc284b91ba9a0a2d284a2e96946c272dc284c4370875412eea855bc30351faedd099dbdbed209e4636"
           }
         ]
       }
@@ -61,7 +61,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -90,14 +89,12 @@
         {
           "license": {
             "id": "CC0-1.0",
-            "name": "Creative Commons Zero v1.0 Universal",
             "url": "https://spdx.org/licenses/CC0-1.0.html"
           }
         },
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -126,7 +123,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -155,8 +151,12 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
+          }
+        },
+        {
+          "license": {
+            "name": "GooglePatentClause"
           }
         }
       ],
@@ -184,7 +184,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -213,7 +212,6 @@
         {
           "license": {
             "id": "Apache-2.0",
-            "name": "Apache License 2.0",
             "url": "https://spdx.org/licenses/Apache-2.0.html"
           }
         }
@@ -242,7 +240,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -271,7 +268,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -300,7 +296,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -329,7 +324,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -358,7 +352,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -387,7 +380,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -416,7 +408,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -445,7 +436,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -474,7 +464,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -503,7 +492,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -532,7 +520,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -561,7 +548,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -590,7 +576,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -619,7 +604,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -648,7 +632,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -677,7 +660,6 @@
         {
           "license": {
             "id": "BSD-2-Clause",
-            "name": "BSD 2-Clause \"Simplified\" License",
             "url": "https://spdx.org/licenses/BSD-2-Clause.html"
           }
         }
@@ -706,14 +688,12 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         },
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -742,7 +722,6 @@
         {
           "license": {
             "id": "MPL-2.0",
-            "name": "Mozilla Public License 2.0",
             "url": "https://spdx.org/licenses/MPL-2.0.html"
           }
         }
@@ -771,7 +750,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -820,7 +798,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -849,7 +826,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -878,7 +854,6 @@
         {
           "license": {
             "id": "Apache-2.0",
-            "name": "Apache License 2.0",
             "url": "https://spdx.org/licenses/Apache-2.0.html"
           }
         }
@@ -907,7 +882,6 @@
         {
           "license": {
             "id": "Apache-2.0",
-            "name": "Apache License 2.0",
             "url": "https://spdx.org/licenses/Apache-2.0.html"
           }
         }
@@ -936,7 +910,6 @@
         {
           "license": {
             "id": "Apache-2.0",
-            "name": "Apache License 2.0",
             "url": "https://spdx.org/licenses/Apache-2.0.html"
           }
         }
@@ -965,7 +938,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -994,7 +966,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -1023,7 +994,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -1052,7 +1022,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -1081,7 +1050,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -1110,7 +1078,6 @@
         {
           "license": {
             "id": "ISC",
-            "name": "ISC License",
             "url": "https://spdx.org/licenses/ISC.html"
           }
         }
@@ -1139,7 +1106,6 @@
         {
           "license": {
             "id": "Apache-2.0",
-            "name": "Apache License 2.0",
             "url": "https://spdx.org/licenses/Apache-2.0.html"
           }
         }
@@ -1188,7 +1154,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -1237,7 +1202,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -1266,7 +1230,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -1315,7 +1278,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -1344,7 +1306,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -1373,7 +1334,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -1402,7 +1362,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -1431,7 +1390,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -1460,7 +1418,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -1489,7 +1446,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -1518,7 +1474,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -1547,7 +1502,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -1576,7 +1530,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -1605,7 +1558,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -1634,7 +1586,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -1683,7 +1634,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -1712,7 +1662,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -1741,7 +1690,6 @@
         {
           "license": {
             "id": "Apache-2.0",
-            "name": "Apache License 2.0",
             "url": "https://spdx.org/licenses/Apache-2.0.html"
           }
         }
@@ -1770,7 +1718,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -1799,7 +1746,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -1828,7 +1774,6 @@
         {
           "license": {
             "id": "BSD-2-Clause",
-            "name": "BSD 2-Clause \"Simplified\" License",
             "url": "https://spdx.org/licenses/BSD-2-Clause.html"
           }
         }
@@ -1857,7 +1802,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -1886,7 +1830,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -1915,7 +1858,6 @@
         {
           "license": {
             "id": "BSD-2-Clause",
-            "name": "BSD 2-Clause \"Simplified\" License",
             "url": "https://spdx.org/licenses/BSD-2-Clause.html"
           }
         }
@@ -1944,7 +1886,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -1973,7 +1914,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -2002,7 +1942,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -2031,7 +1970,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -2060,7 +1998,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -2089,7 +2026,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -2118,7 +2054,6 @@
         {
           "license": {
             "id": "Apache-2.0",
-            "name": "Apache License 2.0",
             "url": "https://spdx.org/licenses/Apache-2.0.html"
           }
         }
@@ -2147,7 +2082,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -2176,7 +2110,6 @@
         {
           "license": {
             "id": "Apache-2.0",
-            "name": "Apache License 2.0",
             "url": "https://spdx.org/licenses/Apache-2.0.html"
           }
         }
@@ -2205,7 +2138,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -2234,7 +2166,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -2263,7 +2194,6 @@
         {
           "license": {
             "id": "Apache-2.0",
-            "name": "Apache License 2.0",
             "url": "https://spdx.org/licenses/Apache-2.0.html"
           }
         }
@@ -2292,7 +2222,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -2321,7 +2250,6 @@
         {
           "license": {
             "id": "BSD-2-Clause",
-            "name": "BSD 2-Clause \"Simplified\" License",
             "url": "https://spdx.org/licenses/BSD-2-Clause.html"
           }
         }
@@ -2350,7 +2278,6 @@
         {
           "license": {
             "id": "BSD-2-Clause",
-            "name": "BSD 2-Clause \"Simplified\" License",
             "url": "https://spdx.org/licenses/BSD-2-Clause.html"
           }
         }
@@ -2379,7 +2306,6 @@
         {
           "license": {
             "id": "MPL-2.0",
-            "name": "Mozilla Public License 2.0",
             "url": "https://spdx.org/licenses/MPL-2.0.html"
           }
         }
@@ -2408,7 +2334,6 @@
         {
           "license": {
             "id": "MPL-2.0",
-            "name": "Mozilla Public License 2.0",
             "url": "https://spdx.org/licenses/MPL-2.0.html"
           }
         }
@@ -2437,7 +2362,6 @@
         {
           "license": {
             "id": "MPL-2.0",
-            "name": "Mozilla Public License 2.0",
             "url": "https://spdx.org/licenses/MPL-2.0.html"
           }
         }
@@ -2466,7 +2390,6 @@
         {
           "license": {
             "id": "MPL-2.0",
-            "name": "Mozilla Public License 2.0",
             "url": "https://spdx.org/licenses/MPL-2.0.html"
           }
         }
@@ -2495,7 +2418,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -2524,7 +2446,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -2553,7 +2474,6 @@
         {
           "license": {
             "id": "Apache-2.0",
-            "name": "Apache License 2.0",
             "url": "https://spdx.org/licenses/Apache-2.0.html"
           }
         }
@@ -2582,7 +2502,6 @@
         {
           "license": {
             "id": "BSD-2-Clause",
-            "name": "BSD 2-Clause \"Simplified\" License",
             "url": "https://spdx.org/licenses/BSD-2-Clause.html"
           }
         }
@@ -2611,7 +2530,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -2640,7 +2558,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -2669,7 +2586,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -2718,7 +2634,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -2747,7 +2662,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -2776,7 +2690,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -2805,7 +2718,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -2834,7 +2746,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -2863,7 +2774,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -2892,7 +2802,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -2921,7 +2830,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -2950,7 +2858,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -2979,7 +2886,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -3008,7 +2914,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -3037,7 +2942,6 @@
         {
           "license": {
             "id": "BSD-2-Clause",
-            "name": "BSD 2-Clause \"Simplified\" License",
             "url": "https://spdx.org/licenses/BSD-2-Clause.html"
           }
         }
@@ -3066,7 +2970,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -3095,7 +2998,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -3124,7 +3026,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -3153,7 +3054,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -3182,7 +3082,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -3211,7 +3110,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -3240,7 +3138,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -3269,7 +3166,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -3298,7 +3194,6 @@
         {
           "license": {
             "id": "Unlicense",
-            "name": "The Unlicense",
             "url": "https://spdx.org/licenses/Unlicense.html"
           }
         }
@@ -3327,7 +3222,6 @@
         {
           "license": {
             "id": "BSD-2-Clause",
-            "name": "BSD 2-Clause \"Simplified\" License",
             "url": "https://spdx.org/licenses/BSD-2-Clause.html"
           }
         }
@@ -3356,7 +3250,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -3385,7 +3278,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -3414,7 +3306,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -3443,7 +3334,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -3492,7 +3382,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -3521,7 +3410,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -3550,7 +3438,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -3579,7 +3466,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -3608,7 +3494,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -3637,7 +3522,6 @@
         {
           "license": {
             "id": "Apache-2.0",
-            "name": "Apache License 2.0",
             "url": "https://spdx.org/licenses/Apache-2.0.html"
           }
         }
@@ -3666,7 +3550,6 @@
         {
           "license": {
             "id": "Apache-2.0",
-            "name": "Apache License 2.0",
             "url": "https://spdx.org/licenses/Apache-2.0.html"
           }
         }
@@ -3695,7 +3578,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -3724,7 +3606,6 @@
         {
           "license": {
             "id": "Apache-2.0",
-            "name": "Apache License 2.0",
             "url": "https://spdx.org/licenses/Apache-2.0.html"
           }
         }
@@ -3753,7 +3634,6 @@
         {
           "license": {
             "id": "Apache-2.0",
-            "name": "Apache License 2.0",
             "url": "https://spdx.org/licenses/Apache-2.0.html"
           }
         }
@@ -3782,7 +3662,6 @@
         {
           "license": {
             "id": "Apache-2.0",
-            "name": "Apache License 2.0",
             "url": "https://spdx.org/licenses/Apache-2.0.html"
           }
         }
@@ -3811,7 +3690,6 @@
         {
           "license": {
             "id": "Apache-2.0",
-            "name": "Apache License 2.0",
             "url": "https://spdx.org/licenses/Apache-2.0.html"
           }
         }
@@ -3840,7 +3718,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -3869,7 +3746,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -3898,7 +3774,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -3927,7 +3802,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -3956,7 +3830,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -3985,7 +3858,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -4014,7 +3886,6 @@
         {
           "license": {
             "id": "BSD-2-Clause",
-            "name": "BSD 2-Clause \"Simplified\" License",
             "url": "https://spdx.org/licenses/BSD-2-Clause.html"
           }
         }
@@ -4043,7 +3914,6 @@
         {
           "license": {
             "id": "BSD-2-Clause",
-            "name": "BSD 2-Clause \"Simplified\" License",
             "url": "https://spdx.org/licenses/BSD-2-Clause.html"
           }
         }
@@ -4072,7 +3942,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -4101,7 +3970,6 @@
         {
           "license": {
             "id": "BSD-2-Clause",
-            "name": "BSD 2-Clause \"Simplified\" License",
             "url": "https://spdx.org/licenses/BSD-2-Clause.html"
           }
         }
@@ -4130,7 +3998,6 @@
         {
           "license": {
             "id": "BSD-2-Clause",
-            "name": "BSD 2-Clause \"Simplified\" License",
             "url": "https://spdx.org/licenses/BSD-2-Clause.html"
           }
         }
@@ -4159,7 +4026,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -4188,7 +4054,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -4217,7 +4082,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -4246,7 +4110,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -4275,7 +4138,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -4304,7 +4166,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -4333,7 +4194,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -4362,7 +4222,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -4391,7 +4250,6 @@
         {
           "license": {
             "id": "Apache-2.0",
-            "name": "Apache License 2.0",
             "url": "https://spdx.org/licenses/Apache-2.0.html"
           }
         }
@@ -4420,7 +4278,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -4449,7 +4306,6 @@
         {
           "license": {
             "id": "Apache-2.0",
-            "name": "Apache License 2.0",
             "url": "https://spdx.org/licenses/Apache-2.0.html"
           }
         }
@@ -4478,7 +4334,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -4507,7 +4362,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -4536,7 +4390,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -4565,7 +4418,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -4594,7 +4446,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -4623,7 +4474,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -4652,7 +4502,6 @@
         {
           "license": {
             "id": "LGPL-3.0",
-            "name": "GNU Lesser General Public License v3.0 only",
             "url": "https://spdx.org/licenses/LGPL-3.0.html"
           }
         }
@@ -4681,7 +4530,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -4710,7 +4558,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -4739,7 +4586,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -4768,7 +4614,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -4797,7 +4642,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -4826,7 +4670,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -4855,7 +4698,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -4884,7 +4726,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -4913,7 +4754,6 @@
         {
           "license": {
             "id": "BSD-2-Clause",
-            "name": "BSD 2-Clause \"Simplified\" License",
             "url": "https://spdx.org/licenses/BSD-2-Clause.html"
           }
         }
@@ -4942,7 +4782,6 @@
         {
           "license": {
             "id": "BSD-2-Clause",
-            "name": "BSD 2-Clause \"Simplified\" License",
             "url": "https://spdx.org/licenses/BSD-2-Clause.html"
           }
         }
@@ -4971,7 +4810,6 @@
         {
           "license": {
             "id": "Apache-2.0",
-            "name": "Apache License 2.0",
             "url": "https://spdx.org/licenses/Apache-2.0.html"
           }
         }
@@ -5000,7 +4838,6 @@
         {
           "license": {
             "id": "Apache-2.0",
-            "name": "Apache License 2.0",
             "url": "https://spdx.org/licenses/Apache-2.0.html"
           }
         }
@@ -5029,7 +4866,6 @@
         {
           "license": {
             "id": "Apache-2.0",
-            "name": "Apache License 2.0",
             "url": "https://spdx.org/licenses/Apache-2.0.html"
           }
         }
@@ -5058,7 +4894,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -5087,7 +4922,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -5116,7 +4950,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -5145,7 +4978,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -5194,7 +5026,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -5217,7 +5048,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -5246,7 +5076,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -5269,7 +5098,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -5292,7 +5120,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -5315,7 +5142,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -5338,7 +5164,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -5361,7 +5186,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -5384,7 +5208,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -5407,7 +5230,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -5430,7 +5252,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -5453,7 +5274,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -5476,7 +5296,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -5499,7 +5318,6 @@
         {
           "license": {
             "id": "BSD-2-Clause",
-            "name": "BSD 2-Clause \"Simplified\" License",
             "url": "https://spdx.org/licenses/BSD-2-Clause.html"
           }
         }
@@ -5528,7 +5346,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -5557,7 +5374,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -5586,7 +5402,6 @@
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }
@@ -5615,7 +5430,6 @@
         {
           "license": {
             "id": "Apache-2.0",
-            "name": "Apache License 2.0",
             "url": "https://spdx.org/licenses/Apache-2.0.html"
           }
         }
@@ -5644,7 +5458,6 @@
         {
           "license": {
             "id": "BSD-2-Clause",
-            "name": "BSD 2-Clause \"Simplified\" License",
             "url": "https://spdx.org/licenses/BSD-2-Clause.html"
           }
         }
@@ -5673,7 +5486,6 @@
         {
           "license": {
             "id": "BSD-3-Clause",
-            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
             "url": "https://spdx.org/licenses/BSD-3-Clause.html"
           }
         }
@@ -5702,7 +5514,6 @@
         {
           "license": {
             "id": "Apache-2.0",
-            "name": "Apache License 2.0",
             "url": "https://spdx.org/licenses/Apache-2.0.html"
           }
         }
@@ -5731,14 +5542,12 @@
         {
           "license": {
             "id": "Apache-2.0",
-            "name": "Apache License 2.0",
             "url": "https://spdx.org/licenses/Apache-2.0.html"
           }
         },
         {
           "license": {
             "id": "MIT",
-            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html"
           }
         }

--- a/proton-bridge/proton-bridge-v1.8.0.bom.xml
+++ b/proton-bridge/proton-bridge-v1.8.0.bom.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.2" serialNumber="urn:uuid:6eb3fb07-a708-47b1-b7d9-9401060d825b" version="1">
+<bom xmlns="http://cyclonedx.org/schema/bom/1.2" serialNumber="urn:uuid:c609c10a-0764-4c10-9ff4-6e544322a2a6" version="1">
   <metadata>
-    <timestamp>2021-04-01T21:11:34+02:00</timestamp>
+    <timestamp>2021-05-16T15:41:15+02:00</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
         <name>cyclonedx-gomod</name>
-        <version>v0.3.0</version>
+        <version>v0.6.0</version>
         <hashes>
-          <hash alg="MD5">4ef5ffbaf5aefe235e0bf1975a522868</hash>
-          <hash alg="SHA-1">1606bc722340cadabdb8f765e47b66a3bb361cea</hash>
-          <hash alg="SHA-256">409a8557fd9d1e3a4c46b0fa9253ec4d678ce0b21f6e970debb7c513eaf2db5f</hash>
-          <hash alg="SHA-512">381675723761dab7f60781df57953844ae9f637d57f073031fbe609c11c0451a7579f0b5675f5d62e5028e30eae0c0555e8089ce852bf3b3524096b28e1a819f</hash>
+          <hash alg="MD5">d0517cb759962ccf9c41c8a12875a8f4</hash>
+          <hash alg="SHA-1">0a7059c2ba93d66a6f3b895ea446a74ab8cf24d0</hash>
+          <hash alg="SHA-256">d9695be77c111ebff786b384581b76ccbf4e8e4463969f6e6e22e9dd9a7ed465</hash>
+          <hash alg="SHA-512">9e6f27516614980c9a745574dcf755679efaacf5cf2beafaf1a5ad67ff99f568f811bbac65e9641f3f82c9da8066d28e5487f52f6b1fa179ec9a878e8a7d461d</hash>
         </hashes>
       </tool>
     </tools>
-    <component bom-ref="pkg:golang/github.com/ProtonMail/proton-bridge@v1.6.3" type="application">
+    <component bom-ref="pkg:golang/github.com/ProtonMail/proton-bridge@v1.8.0" type="application">
       <name>github.com/ProtonMail/proton-bridge</name>
-      <version>v1.6.3</version>
-      <purl>pkg:golang/github.com/ProtonMail/proton-bridge@v1.6.3</purl>
+      <version>v1.8.0</version>
+      <purl>pkg:golang/github.com/ProtonMail/proton-bridge@v1.8.0</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/ProtonMail/proton-bridge</url>
@@ -34,6 +34,13 @@
       <hashes>
         <hash alg="SHA-256">8fd1da69f6a90db3db1910e4bba7bf1d1b3a28131c287896726d7ff526f19e5e</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/0xAX/notificator@v0.0.0-20191016112426-3962a5ea8da1</purl>
       <externalReferences>
         <reference type="vcs">
@@ -48,6 +55,18 @@
       <hashes>
         <hash alg="SHA-256">1c3f20036b6407284c03061a1405fdc3697bbf1bc143934ca310eb921aa1b67e</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>CC0-1.0</id>
+          <name>Creative Commons Zero v1.0 Universal</name>
+          <url>https://spdx.org/licenses/CC0-1.0.html</url>
+        </license>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/AndreasBriese/bbloom@v0.0.0-20190306092124-e2d15f34fcf9</purl>
       <externalReferences>
         <reference type="vcs">
@@ -62,6 +81,13 @@
       <hashes>
         <hash alg="SHA-256">597918625e98af7a817f52bbf440672f899a9343a29817c1d1751ff55976f0e4</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/BurntSushi/toml@v0.3.1</purl>
       <externalReferences>
         <reference type="vcs">
@@ -76,6 +102,13 @@
       <hashes>
         <hash alg="SHA-256">d410d3cf4bbd9c2dfffe938231d347f828972556098795103423811bb8db10b7</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/BurntSushi/xgb@v0.0.0-20160522181843-27f122750802</purl>
       <externalReferences>
         <reference type="vcs">
@@ -90,6 +123,13 @@
       <hashes>
         <hash alg="SHA-256">b11fbff186f8b25b6d078bc3f9bf5bb551275a02f7434d0e053cd54fc07d0b47</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/CloudyKit/fastprinter@v0.0.0-20200109182630-33d98a066a53</purl>
       <externalReferences>
         <reference type="vcs">
@@ -104,6 +144,13 @@
       <hashes>
         <hash alg="SHA-256">d4fc0ee70e550ad954525f8a4ce06c4c66658635a47326ec19a01abb9dad3b2f</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <name>Apache License 2.0</name>
+          <url>https://spdx.org/licenses/Apache-2.0.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/CloudyKit/jet/v3@v3.0.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -118,6 +165,13 @@
       <hashes>
         <hash alg="SHA-256">eb9fa2b8961d457bff5f237ad82d6e12698ec77e37dab346feb2a55fa57b2a47</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/Joker/hpp@v1.0.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -132,6 +186,13 @@
       <hashes>
         <hash alg="SHA-256">6369540ec14a5514981a88cb275c8bc525dd3263184d896cd2b0afa2a98c5109</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/Masterminds/semver/v3@v3.1.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -146,6 +207,13 @@
       <hashes>
         <hash alg="SHA-256">7d72b62ac7e790157d361fbd48acc7721623b84f6cd2f236d091b599bb4401c7</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/ProtonMail/go-autostart@v0.0.0-20181114175602-c5272053443a</purl>
       <externalReferences>
         <reference type="vcs">
@@ -160,6 +228,13 @@
       <hashes>
         <hash alg="SHA-256">a509232442c76b25b9f63a7baf81b90e59a789caf931c7a30dfc2c8dcc08d525</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/ProtonMail/go-crypto@v0.0.0-20201208171014-cdb7591792e2</purl>
       <externalReferences>
         <reference type="vcs">
@@ -174,6 +249,13 @@
       <hashes>
         <hash alg="SHA-256">e64a10a334c310bca660ec856d0fd54ae6dec40117cc347ca8633998ef0645dc</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/ProtonMail/go-imap-id@v0.0.0-20190926060100-f94a56b9ecde</purl>
       <externalReferences>
         <reference type="vcs">
@@ -188,6 +270,13 @@
       <hashes>
         <hash alg="SHA-256">5ba46b80dfec4f18359acab31456fe1bcd0c166a63330eb5214fac966fb0967e</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/ProtonMail/go-mime@v0.0.0-20190923161245-9b5a4261663a</purl>
       <externalReferences>
         <reference type="vcs">
@@ -202,6 +291,13 @@
       <hashes>
         <hash alg="SHA-256">2db2968e07efba66190abf01806c93524dc44c69052c08d0764b9252967909c1</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/ProtonMail/go-rfc5322@v0.5.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -216,6 +312,13 @@
       <hashes>
         <hash alg="SHA-256">5206b50c714de06531b8342bd05ef5b698bc23d1ea3c8959a1d640235951e954</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/ProtonMail/go-vcard@v0.0.0-20180326232728-33aaa0a0c8a5</purl>
       <externalReferences>
         <reference type="vcs">
@@ -230,6 +333,13 @@
       <hashes>
         <hash alg="SHA-256">e3e9c50c9f56b5c5104e2a7f8ded8b9773f6d57840525e1ab16b1a7cbaf0f7b7</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/ProtonMail/gopenpgp/v2@v2.1.3</purl>
       <externalReferences>
         <reference type="vcs">
@@ -244,6 +354,13 @@
       <hashes>
         <hash alg="SHA-256">3d23c11a77bc348516c3effbbc5055fa41b627fe4c3a36f373bd79e0e68a0921</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/PuerkitoBio/goquery@v1.5.1</purl>
       <externalReferences>
         <reference type="vcs">
@@ -258,6 +375,13 @@
       <hashes>
         <hash alg="SHA-256">5830bac92a49cdbc4658587868cc45142dbcc301a9e6912ea13b6f038abfa90e</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/Shopify/goreferrer@v0.0.0-20181106222321-ec9c9a553398</purl>
       <externalReferences>
         <reference type="vcs">
@@ -272,6 +396,13 @@
       <hashes>
         <hash alg="SHA-256">8d07f1eba8739e5600b70cc656d8505a7d052643c1f03240f3d56c500f47b876</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/abiosoft/ishell@v2.0.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -286,6 +417,13 @@
       <hashes>
         <hash alg="SHA-256">0a33d44973a2629b4b6d376bd5171eb9981214343b535e484c44541ab50e471f</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/abiosoft/readline@v0.0.0-20180607040430-155bce2042db</purl>
       <externalReferences>
         <reference type="vcs">
@@ -300,6 +438,13 @@
       <hashes>
         <hash alg="SHA-256">b7d73bbfc2542aefd7c4e181534ca336968c968c4610985492a151ab489b19e5</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/ajg/form@v1.5.1</purl>
       <externalReferences>
         <reference type="vcs">
@@ -314,6 +459,13 @@
       <hashes>
         <hash alg="SHA-256">99971ad3f1d9fd75973fdb7191f765d861fa994cc1a80972273deee4b83c7ee0</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/allan-simon/go-singleinstance@v0.0.0-20160830203053-79edcfdc2dfc</purl>
       <externalReferences>
         <reference type="vcs">
@@ -328,6 +480,13 @@
       <hashes>
         <hash alg="SHA-256">06eb8eeac49f40d151bb52e9a606c3db91ebdaf2d85b6e49bf11ece73cec2d3a</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>BSD-2-Clause</id>
+          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/andybalholm/cascadia@v1.1.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -342,6 +501,18 @@
       <hashes>
         <hash alg="SHA-256">8ff0b69313dfc84d1df3bfe08008c8b0257909d92a9a36fe3b45bc5bed49f886</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/antlr/antlr4@v0.0.0-20201029161626-9a95f0cc3d7c</purl>
       <externalReferences>
         <reference type="vcs">
@@ -356,6 +527,13 @@
       <hashes>
         <hash alg="SHA-256">1b56cfbdc8b037217b21498a5cdb7d024de6eaef43135ac5f919ad22406955d0</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MPL-2.0</id>
+          <name>Mozilla Public License 2.0</name>
+          <url>https://spdx.org/licenses/MPL-2.0.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/armon/consul-api@v0.0.0-20180202201655-eb2c6b5be1b6</purl>
       <externalReferences>
         <reference type="vcs">
@@ -370,6 +548,13 @@
       <hashes>
         <hash alg="SHA-256">901a7783930a0426984323b3db44d35643a9cadacc01a92f2fb43fcf530b35cf</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/aymerick/raymond@v2.0.3-0.20180322193309-b565731e1464</purl>
       <externalReferences>
         <reference type="vcs">
@@ -398,6 +583,13 @@
       <hashes>
         <hash alg="SHA-256">abbeb7a9ff61b8dd7590341abd6b2865724d5b7c44138249c876b9436e7fb1df</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/chzyer/test@v0.0.0-20180213035817-a1ea475d72b1</purl>
       <externalReferences>
         <reference type="vcs">
@@ -412,6 +604,13 @@
       <hashes>
         <hash alg="SHA-256">b033269beabfdfe06e91d229c703b7eb9bff45bb29a7636de579ed810457abc4</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/codegangsta/inject@v0.0.0-20150114235600-33e0aa1cb7c0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -426,6 +625,13 @@
       <hashes>
         <hash alg="SHA-256">a1d778f324614e5305c1bc3b560cea519671ae74a7f543baf8f691436c8a04d6</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <name>Apache License 2.0</name>
+          <url>https://spdx.org/licenses/Apache-2.0.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/coreos/etcd@v3.3.10</purl>
       <externalReferences>
         <reference type="vcs">
@@ -440,6 +646,13 @@
       <hashes>
         <hash alg="SHA-256">59a79e10ff2bd1332fc3a102b612acc787b325fc00354abbba215db513c291c5</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <name>Apache License 2.0</name>
+          <url>https://spdx.org/licenses/Apache-2.0.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/coreos/go-etcd@v2.0.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -454,6 +667,13 @@
       <hashes>
         <hash alg="SHA-256">dc99b7b4b9ac80061c8c2fb8529ee126b1413ebfa7eeb02a61e4b0fd265acee6</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <name>Apache License 2.0</name>
+          <url>https://spdx.org/licenses/Apache-2.0.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/coreos/go-semver@v0.2.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -468,6 +688,13 @@
       <hashes>
         <hash alg="SHA-256">05228c3656310ef9ee9e54f29aab6038d8cd9da455d6c4e9728bf0c23176da39</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/cpuguy83/go-md2man@v1.0.10</purl>
       <externalReferences>
         <reference type="vcs">
@@ -482,6 +709,13 @@
       <hashes>
         <hash alg="SHA-256">53eb3dd144d2620a6d64cc10876691af72ee6b32c921af8f83729cd729526156</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/cpuguy83/go-md2man/v2@v2.0.0-20190314233015-f79a8a8ca69d</purl>
       <externalReferences>
         <reference type="vcs">
@@ -496,6 +730,13 @@
       <hashes>
         <hash alg="SHA-256">b8399a1b371d8e11788bfa65823984b2b887d75634a3b44a6a911ffcb0da337c</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/creack/pty@v1.1.9</purl>
       <externalReferences>
         <reference type="vcs">
@@ -510,6 +751,13 @@
       <hashes>
         <hash alg="SHA-256">9556fe5f8d48e180eb784fa26d9e746dd5e6c92c6046f898160298e80c385c4f</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/cucumber/godog@v0.8.1</purl>
       <externalReferences>
         <reference type="vcs">
@@ -524,6 +772,13 @@
       <hashes>
         <hash alg="SHA-256">dd135c129060e088480a165d15149d950b754230a9d6c3003c8ace9e6ed87fc8</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/danieljoos/wincred@v1.1.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -538,6 +793,13 @@
       <hashes>
         <hash alg="SHA-256">be3f63feed5baa7bc211f24ec1486d94e011aacdfeae41d8635de36164d4f7b7</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>ISC</id>
+          <name>ISC License</name>
+          <url>https://spdx.org/licenses/ISC.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/davecgh/go-spew@v1.1.1</purl>
       <externalReferences>
         <reference type="vcs">
@@ -552,6 +814,13 @@
       <hashes>
         <hash alg="SHA-256">0ec8711716565d470ed315f8efa5490b4ed7b2be990815511ca67ddce87b12fa</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <name>Apache License 2.0</name>
+          <url>https://spdx.org/licenses/Apache-2.0.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/dgraph-io/badger@v1.6.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -580,6 +849,13 @@
       <hashes>
         <hash alg="SHA-256">b5d9590a967f3fd0e17330934a2c6020a9b03efebec0fe431a3a8b630e525220</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/dgryski/go-farm@v0.0.0-20190423205320-6a90982ecee2</purl>
       <externalReferences>
         <reference type="vcs">
@@ -608,6 +884,13 @@
       <hashes>
         <hash alg="SHA-256">5529d3b180a79451da336fe280ed61e97dc703bd637286d0bb17a6824ab8cd8a</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/dustin/go-humanize@v1.0.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -622,6 +905,13 @@
       <hashes>
         <hash alg="SHA-256">7250b59570697b69138f654775a22ef5a8d941ee2470463d8f436c9c30c1677a</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/eknkc/amber@v0.0.0-20171010120322-cdade1c07385</purl>
       <externalReferences>
         <reference type="vcs">
@@ -650,6 +940,13 @@
       <hashes>
         <hash alg="SHA-256">6cc7523e6eacb2cb8e16921abdebb75c60228cc4b74ead92dc4a8566667189d7</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/emersion/go-imap-appendlimit@v0.0.0-20190308131241-25671c986a6a</purl>
       <externalReferences>
         <reference type="vcs">
@@ -664,6 +961,13 @@
       <hashes>
         <hash alg="SHA-256">fc92002f398276e7f9a3c4d625288e0734dbf7e47448287012552b24b969da9a</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/emersion/go-imap-idle@v0.0.0-20200601154248-f05f54664cc4</purl>
       <externalReferences>
         <reference type="vcs">
@@ -678,6 +982,13 @@
       <hashes>
         <hash alg="SHA-256">e69d6ddded4fa266202d6c04c21c0453991507073201c56b3a97b1bfc01e671d</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/emersion/go-imap-move@v0.0.0-20190710073258-6e5a51a5b342</purl>
       <externalReferences>
         <reference type="vcs">
@@ -685,14 +996,21 @@
         </reference>
       </externalReferences>
     </component>
-    <component bom-ref="pkg:golang/github.com/emersion/go-imap-quota@v0.0.0-20200423100218-dcfd1b7d2b41" type="library">
+    <component bom-ref="pkg:golang/github.com/emersion/go-imap-quota@v0.0.0-20210203125329-619074823f3c" type="library">
       <name>github.com/emersion/go-imap-quota</name>
-      <version>v0.0.0-20200423100218-dcfd1b7d2b41</version>
+      <version>v0.0.0-20210203125329-619074823f3c</version>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">cf99431a749445ab8110374d2e3de8d3e1e881560a40219e63702797fc7245f5</hash>
+        <hash alg="SHA-256">92170476ed721626630608bb8069d088b8694a08212746139ca0f4978114aaa7</hash>
       </hashes>
-      <purl>pkg:golang/github.com/emersion/go-imap-quota@v0.0.0-20200423100218-dcfd1b7d2b41</purl>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/emersion/go-imap-quota@v0.0.0-20210203125329-619074823f3c</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/emersion/go-imap-quota</url>
@@ -706,6 +1024,13 @@
       <hashes>
         <hash alg="SHA-256">16249bf3e5c14104a4717dee6ebfb5b40b6544905868599166a380c1e67d5b2f</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/emersion/go-imap-unselect@v0.0.0-20171113212723-b985794e5f26</purl>
       <externalReferences>
         <reference type="vcs">
@@ -720,6 +1045,13 @@
       <hashes>
         <hash alg="SHA-256">b44feb4fe944ba02bdcb49b21329820879f0959374e219573eb6ca9314410392</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/emersion/go-mbox@v1.0.2</purl>
       <externalReferences>
         <reference type="vcs">
@@ -734,6 +1066,13 @@
       <hashes>
         <hash alg="SHA-256">c58ba15ba7a04da08ffb38db51c7e8cbf0ebdc049d54f47d5bb7e6907bd91cf1</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/emersion/go-message@v0.12.1-0.20201221184100-40c3f864532b</purl>
       <externalReferences>
         <reference type="vcs">
@@ -748,6 +1087,13 @@
       <hashes>
         <hash alg="SHA-256">389c9418c253cc74ddd57429f7c4136877ab9f1318cd168e6ac462afd8549454</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/emersion/go-sasl@v0.0.0-20200509203442-7bfe0ed36a21</purl>
       <externalReferences>
         <reference type="vcs">
@@ -762,6 +1108,13 @@
       <hashes>
         <hash alg="SHA-256">4585b6d37a7e11c3e32fc67f6694fd959ea239cf0c1b5310cc4c7550a1245e50</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/emersion/go-smtp@v0.14.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -776,6 +1129,13 @@
       <hashes>
         <hash alg="SHA-256">21b141b70a13432c347c8339c6fd4717e63edd98a30d1f37f5632e960c427146</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/emersion/go-textwrapper@v0.0.0-20200911093747-65d896831594</purl>
       <externalReferences>
         <reference type="vcs">
@@ -790,6 +1150,13 @@
       <hashes>
         <hash alg="SHA-256">9fdab1f7cc624b9578c76588a4f0b6aebf6650ce6b8bdaff62108429b8421eba</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/emersion/go-vcard@v0.0.0-20190105225839-8856043f13c5</purl>
       <externalReferences>
         <reference type="vcs">
@@ -804,6 +1171,13 @@
       <hashes>
         <hash alg="SHA-256">812266c6bb37ecb813a91fe8c89056a24ea4e92bd71147ab1536e5b488579013</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/etcd-io/bbolt@v1.3.3</purl>
       <externalReferences>
         <reference type="vcs">
@@ -832,6 +1206,13 @@
       <hashes>
         <hash alg="SHA-256">f313c7978fead55caa1883e27f517ed55dd8de54a6aead3511a6d45b70a85b9b</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/fatih/color@v1.9.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -846,6 +1227,13 @@
       <hashes>
         <hash alg="SHA-256">43b8ee0ccd10b5c9e10a97b22c640aca0e13388821b8d5eb90bdf6a47014331a</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/fatih/structs@v1.1.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -860,6 +1248,13 @@
       <hashes>
         <hash alg="SHA-256">04c5d86115932ce24a961fa5381b7a9d44205c07c1ee854842de5c36b7aa48b2</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <name>Apache License 2.0</name>
+          <url>https://spdx.org/licenses/Apache-2.0.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/flynn-archive/go-shlex@v0.0.0-20150515145356-3f9db97f8568</purl>
       <externalReferences>
         <reference type="vcs">
@@ -874,6 +1269,13 @@
       <hashes>
         <hash alg="SHA-256">217b3e40b9a75d6d82717b98fbc333bff7d612c3c65b1a9e7cfb423f90a757d2</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/fsnotify/fsnotify@v1.4.7</purl>
       <externalReferences>
         <reference type="vcs">
@@ -888,6 +1290,13 @@
       <hashes>
         <hash alg="SHA-256">d5a4f508239e746148054abbe0bc6698ac1c20fe4b3a3573988749e29b213db8</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/gavv/httpexpect@v2.0.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -902,6 +1311,13 @@
       <hashes>
         <hash alg="SHA-256">179d9c8c154bba24df756ea9e0916ec65b77a4e8ca7d6613fda91aedc749eefd</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>BSD-2-Clause</id>
+          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/getsentry/sentry-go@v0.8.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -916,6 +1332,13 @@
       <hashes>
         <hash alg="SHA-256">b7c155930df72fec2295fd90896930d1457beea469707fc91cf286a4a6b613c8</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/gin-contrib/sse@v0.0.0-20190301062529-5545eab6dad3</purl>
       <externalReferences>
         <reference type="vcs">
@@ -930,6 +1353,13 @@
       <hashes>
         <hash alg="SHA-256">ded3280827ccee9a6ab11d29b73ff08b58a6a4da53efff7042d319f25af59824</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/gin-gonic/gin@v1.4.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -944,6 +1374,13 @@
       <hashes>
         <hash alg="SHA-256">d2090fea6cda32a926a5c25808538b90807023bc451311b4ddb6e43a40af50f2</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>BSD-2-Clause</id>
+          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/go-check/check@v0.0.0-20180628173108-788fd7840127</purl>
       <externalReferences>
         <reference type="vcs">
@@ -958,6 +1395,13 @@
       <hashes>
         <hash alg="SHA-256">2d41f39a42b7194294acbff581f054c401f371ebf76a94257b35fff8eee66bac</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/go-errors/errors@v1.0.1</purl>
       <externalReferences>
         <reference type="vcs">
@@ -972,6 +1416,13 @@
       <hashes>
         <hash alg="SHA-256">c6f78a5b3da26ae79e4da52075eb737a5f94edec728a00d806bcb255f57fad99</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/go-martini/martini@v0.0.0-20170121215854-22fa46961aab</purl>
       <externalReferences>
         <reference type="vcs">
@@ -979,14 +1430,21 @@
         </reference>
       </externalReferences>
     </component>
-    <component bom-ref="pkg:golang/github.com/go-resty/resty/v2@v2.3.0" type="library">
+    <component bom-ref="pkg:golang/github.com/go-resty/resty/v2@v2.6.0" type="library">
       <name>github.com/go-resty/resty/v2</name>
-      <version>v2.3.0</version>
+      <version>v2.6.0</version>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">24e39e02f8d295aa534fdda9f31892d7d6717afd677868a4a07b1725e3aaf12a</hash>
+        <hash alg="SHA-256">8e8211e4f34b336105aaa11252308c197ad6997347114f421222bcd77a0a612e</hash>
       </hashes>
-      <purl>pkg:golang/github.com/go-resty/resty/v2@v2.3.0</purl>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/go-resty/resty/v2@v2.6.0</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/go-resty/resty/v2</url>
@@ -1000,6 +1458,13 @@
       <hashes>
         <hash alg="SHA-256">b3edb528daa5a5e3df91a87623e8301c5f319895918e8a18fb9db8f24ea6e00d</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/gobwas/httphead@v0.0.0-20180130184737-2c6c146eadee</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1014,6 +1479,13 @@
       <hashes>
         <hash alg="SHA-256">4049943a59d28d6b67a5118717749ab8488eb32f360aea7cdd57f62dc3259dcf</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/gobwas/pool@v0.2.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1028,6 +1500,13 @@
       <hashes>
         <hash alg="SHA-256">0a801abd6ff077f92e95f66648806dea9db89f88fbb4780d5428ec7c754d51ba</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/gobwas/ws@v1.0.2</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1042,6 +1521,13 @@
       <hashes>
         <hash alg="SHA-256">97be425c6452c1b69836997f6765f55c82003120aabaf5e0a5564387010826c7</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <name>Apache License 2.0</name>
+          <url>https://spdx.org/licenses/Apache-2.0.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/golang/mock@v1.4.4</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1056,6 +1542,13 @@
       <hashes>
         <hash alg="SHA-256">605f3e7e50574b978ef36e93e27cea3ebc5f8504e18579746337ee50fbb84818</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/golang/protobuf@v1.3.1</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1070,6 +1563,13 @@
       <hashes>
         <hash alg="SHA-256">cb45a686f9a5edc1a7ccf6bd9e8727fdf32b68c1ff94c0dd786fab931e158186</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <name>Apache License 2.0</name>
+          <url>https://spdx.org/licenses/Apache-2.0.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/gomodule/redigo@v1.7.1-0.20190724094224-574c33c3df38</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1084,6 +1584,13 @@
       <hashes>
         <hash alg="SHA-256">245ac51016f6c4ab9f83a5e426c26bf966ca6f8150954462e5151c06f798bbd9</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/google/go-cmp@v0.5.1</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1098,6 +1605,13 @@
       <hashes>
         <hash alg="SHA-256">5e4c22fdad6b72f360d4f3d87b9bc8f066de058fe3ad5b835f9012b803564eb9</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/google/go-querystring@v1.0.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1112,6 +1626,13 @@
       <hashes>
         <hash alg="SHA-256">03c3de5b9f69c44f48a0546a069dfb53e99235a428678e85d5fd1ff3add7497c</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <name>Apache License 2.0</name>
+          <url>https://spdx.org/licenses/Apache-2.0.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/google/gofuzz@v1.0.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1126,6 +1647,13 @@
       <hashes>
         <hash alg="SHA-256">1a46dcb21fc66e95f3ee53dfb4b0373fa4d83308c22d89bcde388541917fde06</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/google/uuid@v1.1.1</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1140,6 +1668,13 @@
       <hashes>
         <hash alg="SHA-256">ee517e573d0baa2462767cc2d4eabce9fa57d6afe212fd8a25dac2b6db588d3e</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>BSD-2-Clause</id>
+          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/gopherjs/gopherjs@v0.0.0-20190430165422-3e4dfb77656c</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1154,6 +1689,13 @@
       <hashes>
         <hash alg="SHA-256">abb01e0c1a67064f00a20703e0349a83f524c3f295f988732e3d9b3f91ef2823</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>BSD-2-Clause</id>
+          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/gorilla/websocket@v1.4.1</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1168,6 +1710,13 @@
       <hashes>
         <hash alg="SHA-256">84baeab440e74727b7fac831eb3e2a54b36ebe21f7311e5a434ca43496bf5180</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MPL-2.0</id>
+          <name>Mozilla Public License 2.0</name>
+          <url>https://spdx.org/licenses/MPL-2.0.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/hashicorp/errwrap@v1.0.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1182,6 +1731,13 @@
       <hashes>
         <hash alg="SHA-256">07d533c064097a19d4635c8dae7c111077377c66c2db179fa3c8384db12569c2</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MPL-2.0</id>
+          <name>Mozilla Public License 2.0</name>
+          <url>https://spdx.org/licenses/MPL-2.0.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/hashicorp/go-multierror@v1.1.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1196,6 +1752,13 @@
       <hashes>
         <hash alg="SHA-256">def35efdf585e4206044882e75ad6679686c647cb79bc802279c31f9d2335ff1</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MPL-2.0</id>
+          <name>Mozilla Public License 2.0</name>
+          <url>https://spdx.org/licenses/MPL-2.0.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/hashicorp/go-version@v1.2.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1210,6 +1773,13 @@
       <hashes>
         <hash alg="SHA-256">d009e5ce3a62e2f11ab1378d167da62c98134b0b74fbab1fb224c6f2a7161b1e</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MPL-2.0</id>
+          <name>Mozilla Public License 2.0</name>
+          <url>https://spdx.org/licenses/MPL-2.0.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/hashicorp/hcl@v1.0.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1224,6 +1794,13 @@
       <hashes>
         <hash alg="SHA-256">9df08ebca61f92060ff21922ae12687174f6fb3383f3250d8d76967d397214a2</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/hpcloud/tail@v1.0.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1238,6 +1815,13 @@
       <hashes>
         <hash alg="SHA-256">28888aaf45521b60945b5865d63a62caecee25e2945290bc88cd40204ecdd559</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/imkira/go-interpol@v1.1.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1252,6 +1836,13 @@
       <hashes>
         <hash alg="SHA-256">67cb6ee6cada2d709721c011c41a7ff1c6ef97055aed9d4d1e0f5710a86d4af3</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <name>Apache License 2.0</name>
+          <url>https://spdx.org/licenses/Apache-2.0.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/inconshreveable/mousetrap@v1.0.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1266,6 +1857,13 @@
       <hashes>
         <hash alg="SHA-256">c5559ad5703151c00b9cbdf6a4f9ddf9523f0237c1fe0be6e7ba85a99b401409</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>BSD-2-Clause</id>
+          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/iris-contrib/blackfriday@v2.0.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1280,6 +1878,13 @@
       <hashes>
         <hash alg="SHA-256">9db9571d236874d6904bc950503b1018e05b5e904a360fc8e7e299ed6de635d1</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/iris-contrib/go.uuid@v2.0.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1294,6 +1899,13 @@
       <hashes>
         <hash alg="SHA-256">a7b27fe74234723a34c2afd559508315df2d68f25bb850be6eadb74a7891157d</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/iris-contrib/jade@v1.1.3</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1308,6 +1920,13 @@
       <hashes>
         <hash alg="SHA-256">cc63fba56e75a22e5e41930894603723e14763dfc739058307ee7bdb28a7d2da</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/iris-contrib/pongo2@v0.0.1</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1336,6 +1955,13 @@
       <hashes>
         <hash alg="SHA-256">613dae57042245067109a69a8707dc813ab68f78faeb0d349ffdbb81bff3b9bb</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/ProtonMail/bcrypt@v0.0.0-20170924085257-7509ea014998</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1350,6 +1976,13 @@
       <hashes>
         <hash alg="SHA-256">8347c01818ac1da110d1346ad6206f7a61517fef0011612604449289607756c7</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/jaytaylor/html2text@v0.0.0-20200412013138-3577fbdbcff7</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1364,6 +1997,13 @@
       <hashes>
         <hash alg="SHA-256">f72cee77f1eddfaca0c1ab46c79e95c0266d948ff6003d794f55f6b234ae1a7b</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/json-iterator/go@v1.1.9</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1378,6 +2018,13 @@
       <hashes>
         <hash alg="SHA-256">0d61bff8c2de500d8311984d8f3cce613ec6aa4e2b4ecc63d11948dd914bf59f</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/jtolds/gls@v4.20.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1392,6 +2039,13 @@
       <hashes>
         <hash alg="SHA-256">b82d507d29489e9405f8cd1aa3ae629a1c2a2a7cf7436cff77c3d6651310bc33</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/k0kubun/colorstring@v0.0.0-20150214042306-9440f1994b88</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1406,6 +2060,13 @@
       <hashes>
         <hash alg="SHA-256">bd10d1526c1a71ca3fa660409bc81e2e7f2b1c475cfbd678340af94a1ed31bfe</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/kataras/golog@v0.0.10</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1420,6 +2081,13 @@
       <hashes>
         <hash alg="SHA-256">3b78096ac8e6ed9c69c704c7f2d02966cbdfdbbe2c712190014a4d7b8edcdfb5</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/kataras/iris/v12@v12.1.8</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1434,6 +2102,13 @@
       <hashes>
         <hash alg="SHA-256">a5d25a4ef506dcd41f78c6db54223c253d93e60a0f95dcb27d40763c97e1d41b</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/kataras/neffos@v0.0.14</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1448,6 +2123,13 @@
       <hashes>
         <hash alg="SHA-256">e8d022fae3c9fd9ba277a9ab00a960a5b235d7fccafe5578076af159a24df7c6</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/kataras/pio@v0.0.2</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1462,6 +2144,13 @@
       <hashes>
         <hash alg="SHA-256">e0708e357e512e0572e86e11918395def28d7266bda76dfa2dd18e8a926c6851</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/kataras/sitemap@v0.0.5</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1476,6 +2165,13 @@
       <hashes>
         <hash alg="SHA-256">8158e10427d51a5df6448068a0e00dcdfc3ed14a97f0753ec8f94cbfcbf2a5c8</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/keybase/go-keychain@v0.0.0-20200502122510-cda31fe0c86d</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1490,6 +2186,13 @@
       <hashes>
         <hash alg="SHA-256">93dac2aae702b0fa4128387d803c24dd4e3a4dc35dee3a4a6a179df491880866</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>BSD-2-Clause</id>
+          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/keybase/go.dbus@v0.0.0-20200324223359-a94be52c0b03</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1504,6 +2207,13 @@
       <hashes>
         <hash alg="SHA-256">8585b580ff78254980841b49f8b373e4ccbe801a1b0f13d1d6256e2ae836e9a0</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/klauspost/compress@v1.9.7</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1518,6 +2228,13 @@
       <hashes>
         <hash alg="SHA-256">bc98be3bf9cc745b74bea9bc359048eb0cc02d6740d97f9e822d2880dcab0bfc</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/klauspost/cpuid@v1.2.1</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1532,6 +2249,13 @@
       <hashes>
         <hash alg="SHA-256">0c1d7b6a0d7d92bc7d085b33e28dde9d3acf5f22170a5fb68825c7fda300a7db</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/konsorten/go-windows-terminal-sequences@v1.0.2</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1546,6 +2270,13 @@
       <hashes>
         <hash alg="SHA-256">2ff0b0374cdead90e644551aa523e2b64e9ff90dfed336b5ad093356e3223052</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/kr/pretty@v0.1.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1560,6 +2291,13 @@
       <hashes>
         <hash alg="SHA-256">564a1723049ba01a6793df4efca15ab801082ee347bf90d514a64c04dfe0520c</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/kr/pty@v1.1.1</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1574,6 +2312,13 @@
       <hashes>
         <hash alg="SHA-256">e4dc7461ad19a98db2815dfae90cedbab1c8d7726af79029715689061a52f806</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/kr/text@v0.2.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1588,6 +2333,13 @@
       <hashes>
         <hash alg="SHA-256">cf4059a00ad8e05a9da54125fb0947a78867affa1247a3139909aff0e1d2a30c</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/labstack/echo/v4@v4.1.11</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1602,6 +2354,13 @@
       <hashes>
         <hash alg="SHA-256">24478ed1bbdcefc3ca7721f19684ca885f010f9886ac7f13e8c49e1af4a0a1bd</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/labstack/gommon@v0.3.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1616,6 +2375,13 @@
       <hashes>
         <hash alg="SHA-256">2dff73b09ee12bc6bd7e6adc7f970c0337de1439857bdb82bb555526f0382c32</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>Unlicense</id>
+          <name>The Unlicense</name>
+          <url>https://spdx.org/licenses/Unlicense.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/logrusorgru/aurora@v2.0.3</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1630,6 +2396,13 @@
       <hashes>
         <hash alg="SHA-256">2cb8179ac85e5de46850e04e8edc0f40258862a33f2d4d5ac83b4378f7ab45c6</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>BSD-2-Clause</id>
+          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/magiconair/properties@v1.8.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1644,6 +2417,13 @@
       <hashes>
         <hash alg="SHA-256">708c2fbf062c7bfd3ed429143d81f966f548606dc9ac82e640421b2ee6abd366</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/martinlindhe/base36@v1.1.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1658,6 +2438,13 @@
       <hashes>
         <hash alg="SHA-256">b276cf2c1f1f55f53d8b06dba37d133ed6cb473c16bba6894ba5e1e1e69abe20</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/mattn/go-colorable@v0.1.4</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1672,6 +2459,13 @@
       <hashes>
         <hash alg="SHA-256">1713ce4c536a1a4b835068b71ffaa451b40ee198816b66eb2aae6bd25f1319e3</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/mattn/go-isatty@v0.0.11</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1686,6 +2480,13 @@
       <hashes>
         <hash alg="SHA-256">2e6f7de5fdeb7f176977a4d29ae5421d56ff421ba9b97958afcb0223f41d13ed</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/mattn/go-runewidth@v0.0.9</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1714,6 +2515,13 @@
       <hashes>
         <hash alg="SHA-256">81a95b3c18c8c26c91120c0609f4043785fc9716c99ca058bab833f957dc4ad0</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/mediocregopher/radix/v3@v3.4.2</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1728,6 +2536,13 @@
       <hashes>
         <hash alg="SHA-256">e653df2d34c0bc06ed4b456a4fef78c8eb459c67d4598cb1d3e893a02dceb37b</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/microcosm-cc/bluemonday@v1.0.2</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1735,14 +2550,21 @@
         </reference>
       </externalReferences>
     </component>
-    <component bom-ref="pkg:golang/github.com/miekg/dns@v1.1.30" type="library">
+    <component bom-ref="pkg:golang/github.com/miekg/dns@v1.1.41" type="library">
       <name>github.com/miekg/dns</name>
-      <version>v1.1.30</version>
+      <version>v1.1.41</version>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">430c3a16c7859fc3d17f0d3b8ee7aa217aa8766d092a288ab8ad037974aa7f2a</hash>
+        <hash alg="SHA-256">58cb33656246d179b36caf45126cc7d9355ca98cc57acbac488078d5bf0a1f16</hash>
       </hashes>
-      <purl>pkg:golang/github.com/miekg/dns@v1.1.30</purl>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/github.com/miekg/dns@v1.1.41</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/miekg/dns</url>
@@ -1756,6 +2578,13 @@
       <hashes>
         <hash alg="SHA-256">96e905f738971710c53e4035becaf9ce97355ee3c39ffc059edab9986fb81346</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/mitchellh/go-homedir@v1.1.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1770,6 +2599,13 @@
       <hashes>
         <hash alg="SHA-256">7e6358570aa749f07d99953a392d8ee86b1733ec1cb24643b8a433bcdd440de1</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/mitchellh/mapstructure@v1.1.2</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1784,6 +2620,13 @@
       <hashes>
         <hash alg="SHA-256">4d12da67d703ff0f0f561f779ec3d76b556b43a8e5c0be6837c975e1095c35f8</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <name>Apache License 2.0</name>
+          <url>https://spdx.org/licenses/Apache-2.0.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1798,6 +2641,13 @@
       <hashes>
         <hash alg="SHA-256">f5fe35dacfba4666172d665213355580f18aec2d8fa611e3e5126bbdfc7d0162</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <name>Apache License 2.0</name>
+          <url>https://spdx.org/licenses/Apache-2.0.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/modern-go/reflect2@v1.0.1</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1812,6 +2662,13 @@
       <hashes>
         <hash alg="SHA-256">751316a00b5bf9e3f13252e4ac26c0aa1e1394f1d7be8194490df6dfff596a1b</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/moul/http2curl@v1.0.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1826,6 +2683,13 @@
       <hashes>
         <hash alg="SHA-256">c5d9f3c0511357efa335ce16d66c3ffea1722466f60013a899b9992504b8f90a</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <name>Apache License 2.0</name>
+          <url>https://spdx.org/licenses/Apache-2.0.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/nats-io/jwt@v0.3.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1840,6 +2704,13 @@
       <hashes>
         <hash alg="SHA-256">8a4dc76cb859d180012eda3b897f34a592cfc3fe9dc774fefbe3192702e732b4</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <name>Apache License 2.0</name>
+          <url>https://spdx.org/licenses/Apache-2.0.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/nats-io/nats.go@v1.9.1</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1854,6 +2725,13 @@
       <hashes>
         <hash alg="SHA-256">a8c778fa944781daf59c00a5bbeda1ff66b91764e629c0b38c20dacd5811a17e</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <name>Apache License 2.0</name>
+          <url>https://spdx.org/licenses/Apache-2.0.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/nats-io/nkeys@v0.1.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1868,6 +2746,13 @@
       <hashes>
         <hash alg="SHA-256">e6203c0d3f15eeaf162b611272fda969d35afeb4c449cd4a7673f0e130b6a5ac</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <name>Apache License 2.0</name>
+          <url>https://spdx.org/licenses/Apache-2.0.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/nats-io/nuid@v1.0.1</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1882,6 +2767,13 @@
       <hashes>
         <hash alg="SHA-256">7c3e7b11147826d12ab166df3e1bf80cc880a47ca58a22b9c424cd5523e2680b</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1896,6 +2788,13 @@
       <hashes>
         <hash alg="SHA-256">44f7257e06b648426680c9b3da4f8c83b728c19f32bf84ebab0f54b096f2ef9f</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/nsf/jsondiff@v0.0.0-20200515183724-f29ed568f4ce</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1910,6 +2809,13 @@
       <hashes>
         <hash alg="SHA-256">bc70ff6187b55a8968efc9281b6f7d7fb57f5404b4f1ce88a422e7f848dfff0f</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/olekukonko/tablewriter@v0.0.4</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1924,6 +2830,13 @@
       <hashes>
         <hash alg="SHA-256">3a8c5b8df5d5672a1dd5f99662123b484c9a0fc074d329cfdd3f83e468b21ce6</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/onsi/ginkgo@v1.10.3</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1938,6 +2851,13 @@
       <hashes>
         <hash alg="SHA-256">2b48dc442c0d40cdef146875a6932d0e1ffeec0a49ae395d957f1f0348c34cb4</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/onsi/gomega@v1.7.1</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1952,6 +2872,13 @@
       <hashes>
         <hash alg="SHA-256">4f9ccc18c2fad56a7e16571b5a34434fbc80c6124d0223cf2ce1440aad7cd737</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/pelletier/go-toml@v1.2.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1966,6 +2893,13 @@
       <hashes>
         <hash alg="SHA-256">945b9057fa1a50c19c0f6b6ab7ed3544e4a626cef9546d53a043a46486789c4e</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>BSD-2-Clause</id>
+          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/pingcap/errors@v0.11.4</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1980,6 +2914,13 @@
       <hashes>
         <hash alg="SHA-256">14404bc75cd2db5e28c298f2eeab017a2c5b51192e850030acae54c0b193c2de</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>BSD-2-Clause</id>
+          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/pkg/errors@v0.9.1</purl>
       <externalReferences>
         <reference type="vcs">
@@ -1994,6 +2935,13 @@
       <hashes>
         <hash alg="SHA-256">e030700c4d0d1b24280476cb4183f04943e808c591e41133224fdfd6565b0103</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/pmezard/go-difflib@v1.0.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -2008,6 +2956,13 @@
       <hashes>
         <hash alg="SHA-256">1f2bc2d0045f9d906a9d7c00045792647a4abc91c925f3f3f3518db9e2e3d28a</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>BSD-2-Clause</id>
+          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/russross/blackfriday@v1.5.2</purl>
       <externalReferences>
         <reference type="vcs">
@@ -2022,6 +2977,13 @@
       <hashes>
         <hash alg="SHA-256">94fa9502d7be1ee1cd7e127fd0b0bdf04496473f1a7f2f6d33fd112bc9bda3e4</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>BSD-2-Clause</id>
+          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/russross/blackfriday/v2@v2.0.1</purl>
       <externalReferences>
         <reference type="vcs">
@@ -2036,6 +2998,13 @@
       <hashes>
         <hash alg="SHA-256">67857b6becfe4e5a74ee5af8b920af2a90025f5420b85484816ee0a21db5f62c</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/ryanuber/columnize@v2.1.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -2050,6 +3019,13 @@
       <hashes>
         <hash alg="SHA-256">d6b425d6e1e57fc2a49546fd9d947fef0b40c2f06cbeb01a05c45164bd84556a</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/schollz/closestmatch@v2.1.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -2064,6 +3040,13 @@
       <hashes>
         <hash alg="SHA-256">2a971adea44daddb8d9ce41e6b305dd32b1a2ab509888b88487c688244fd44f4</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/sergi/go-diff@v1.0.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -2078,6 +3061,13 @@
       <hashes>
         <hash alg="SHA-256">3dd9a808eeb0bdbb3eef2ac9c8c391b78fc1998e486322704bf90e896c7c987a</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/shurcooL/sanitized_anchor_name@v1.0.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -2092,6 +3082,13 @@
       <hashes>
         <hash alg="SHA-256">4a1ac3d54f69641d764d7d1c572d03b5e3e8087f7b2bc12d5fe9a0ed901152d3</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/sirupsen/logrus@v1.7.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -2106,6 +3103,13 @@
       <hashes>
         <hash alg="SHA-256">24802eab71047fd7206d4e80b463cae024c6dd97fa08a30da9fd0c1d38200140</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/skratchdot/open-golang@v0.0.0-20200116055534-eef842397966</purl>
       <externalReferences>
         <reference type="vcs">
@@ -2120,6 +3124,13 @@
       <hashes>
         <hash alg="SHA-256">cc4f7290495643afcd6261dade3a66ff21e7238c52a1f3fe50fe92a631dc49e3</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/smartystreets/assertions@v0.0.0-20180927180507-b2de0cb4f26d</purl>
       <externalReferences>
         <reference type="vcs">
@@ -2134,6 +3145,13 @@
       <hashes>
         <hash alg="SHA-256">7efd14f0550830f35fd4bf659c72ef2e182272b2150a112477320a62a6cd0bdb</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/smartystreets/goconvey@v1.6.4</purl>
       <externalReferences>
         <reference type="vcs">
@@ -2148,6 +3166,13 @@
       <hashes>
         <hash alg="SHA-256">9bcff3d6deff7f08f2b2341161b3f4443f9b50817ff2d2703dd119b08f370022</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <name>Apache License 2.0</name>
+          <url>https://spdx.org/licenses/Apache-2.0.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/spf13/afero@v1.1.2</purl>
       <externalReferences>
         <reference type="vcs">
@@ -2162,6 +3187,13 @@
       <hashes>
         <hash alg="SHA-256">a207adfff095384a057b0a90c70af4123e728f2827a8692f820484fe0077e50f</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/spf13/cast@v1.3.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -2176,6 +3208,13 @@
       <hashes>
         <hash alg="SHA-256">7f407e2e42d7e83b66447d62b28340f554ed3542bd2bcc58776f0934d7cebffb</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <name>Apache License 2.0</name>
+          <url>https://spdx.org/licenses/Apache-2.0.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/spf13/cobra@v0.0.5</purl>
       <externalReferences>
         <reference type="vcs">
@@ -2190,6 +3229,13 @@
       <hashes>
         <hash alg="SHA-256">5c711dc81f8472f96a65a99233864e30695cf77b7a01cb0112ef46735be7ef29</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/spf13/jwalterweatherman@v1.0.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -2204,6 +3250,13 @@
       <hashes>
         <hash alg="SHA-256">ccf013e821b2eb05de43b36d4e76937ab7ca3ac57a57a17c6a01d71626b30e48</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/spf13/pflag@v1.0.3</purl>
       <externalReferences>
         <reference type="vcs">
@@ -2218,6 +3271,13 @@
       <hashes>
         <hash alg="SHA-256">55416ac3929ca917fb8bbd063b35bb37e43bfa0c55064492aa25c1d76f894383</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/spf13/viper@v1.3.2</purl>
       <externalReferences>
         <reference type="vcs">
@@ -2232,6 +3292,13 @@
       <hashes>
         <hash alg="SHA-256">a6f6d9d253345d63c1a942aa154f1c99abeca6f225f67ba5398c1dcba205451a</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/ssor/bom@v0.0.0-20170718123548-6386211fdfcf</purl>
       <externalReferences>
         <reference type="vcs">
@@ -2246,6 +3313,13 @@
       <hashes>
         <hash alg="SHA-256">1db8363627692c4f2f7840641194cbdc2be5914215cee53d8c3a6564ee78738f</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/stretchr/objx@v0.2.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -2260,6 +3334,13 @@
       <hashes>
         <hash alg="SHA-256">8433ce1e6a4ea4fe3495250b72ac3b22b45bfeeef0e91a430bddfdf57ca835dd</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/stretchr/testify@v1.6.1</purl>
       <externalReferences>
         <reference type="vcs">
@@ -2274,6 +3355,13 @@
       <hashes>
         <hash alg="SHA-256">1b40d0fd3450cab1198ed2e52f07af163691886f1e782325abd59743638ed9b9</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>LGPL-3.0</id>
+          <name>GNU Lesser General Public License v3.0 only</name>
+          <url>https://spdx.org/licenses/LGPL-3.0.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/therecipe/qt@v0.0.0-20200701200531-7f61353ee73e</purl>
       <externalReferences>
         <reference type="vcs">
@@ -2288,6 +3376,13 @@
       <hashes>
         <hash alg="SHA-256">ffaf20cb687ed6658caf0645783d644226a5752cc06f8df676da5e278da8bdda</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/ugorji/go@v1.1.7</purl>
       <externalReferences>
         <reference type="vcs">
@@ -2302,6 +3397,13 @@
       <hashes>
         <hash alg="SHA-256">d92bd0695675a2e62baca2b0a12936a7377803d7af94a25bf684cbf8e68b512b</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/ugorji/go/codec@v1.1.7</purl>
       <externalReferences>
         <reference type="vcs">
@@ -2316,6 +3418,13 @@
       <hashes>
         <hash alg="SHA-256">2534e733ac0acdd03426aa1d77deba3158f8bd66dbaae67291e5f5b0a6ded82e</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/urfave/cli/v2@v2.2.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -2330,6 +3439,13 @@
       <hashes>
         <hash alg="SHA-256">9088a63a2b68ca9ab7e0aed31bb0d4689f64abf37839fbb08b5b23cf42a2a577</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/urfave/negroni@v1.0.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -2344,6 +3460,13 @@
       <hashes>
         <hash alg="SHA-256">1aa0394c2ff4d36d58fdbf451b83a2f4caf7abb5d8c7a2a59736b014885c74fc</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/valyala/bytebufferpool@v1.0.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -2358,6 +3481,13 @@
       <hashes>
         <hash alg="SHA-256">b9617c9602a679a21ec1654fc22e0646ad8febe478e8881865dc56b4cf86b446</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/valyala/fasthttp@v1.6.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -2372,6 +3502,13 @@
       <hashes>
         <hash alg="SHA-256">b58f422623e73177f5111986d84c8aee035477e73a44a183d087d4f167544b3f</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/valyala/fasttemplate@v1.0.1</purl>
       <externalReferences>
         <reference type="vcs">
@@ -2386,6 +3523,13 @@
       <hashes>
         <hash alg="SHA-256">d11e0d2c3443657e897268498178b91386fc5a0f388a16e650aa7f1af48f1337</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/valyala/tcplisten@v0.0.0-20161114210144-ceec8f93295a</purl>
       <externalReferences>
         <reference type="vcs">
@@ -2400,6 +3544,13 @@
       <hashes>
         <hash alg="SHA-256">1700bd28f8f25bc3aa4d4a8cb7aad0c3dcb9d2f0367132d73ca09c04245b4208</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>BSD-2-Clause</id>
+          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/vmihailenco/msgpack/v5@v5.1.3</purl>
       <externalReferences>
         <reference type="vcs">
@@ -2414,6 +3565,13 @@
       <hashes>
         <hash alg="SHA-256">8278e856e07f9258c9e702021043a9c7df285cc58f2e3db61baed56ddd6a3ea7</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>BSD-2-Clause</id>
+          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/vmihailenco/tagparser@v0.1.2</purl>
       <externalReferences>
         <reference type="vcs">
@@ -2428,6 +3586,13 @@
       <hashes>
         <hash alg="SHA-256">27d106a5c66d3f413fadaa2b08cc6514649306bb1295a0c67f78d4feabc01367</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <name>Apache License 2.0</name>
+          <url>https://spdx.org/licenses/Apache-2.0.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/xeipuuv/gojsonpointer@v0.0.0-20180127040702-4e3ac2762d5f</purl>
       <externalReferences>
         <reference type="vcs">
@@ -2442,6 +3607,13 @@
       <hashes>
         <hash alg="SHA-256">133256807a2fa27b7b36c723a40c57b0303c4bc04c62f7bc639fbb72e444ed1d</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <name>Apache License 2.0</name>
+          <url>https://spdx.org/licenses/Apache-2.0.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/xeipuuv/gojsonreference@v0.0.0-20180127040603-bd5ef7bd5415</purl>
       <externalReferences>
         <reference type="vcs">
@@ -2456,6 +3628,13 @@
       <hashes>
         <hash alg="SHA-256">2e160946cf8be1f06d8d951fb92648286795bb4411cbc7b95e2ec3d7b53167be</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <name>Apache License 2.0</name>
+          <url>https://spdx.org/licenses/Apache-2.0.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/xeipuuv/gojsonschema@v1.2.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -2470,6 +3649,13 @@
       <hashes>
         <hash alg="SHA-256">112152770619be47abbb746d76b62e7b3b4a84e0424800334b819ffa4d2d128c</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/xordataexchange/crypt@v0.0.3-0.20170626215501-b2862e3d0a77</purl>
       <externalReferences>
         <reference type="vcs">
@@ -2484,6 +3670,13 @@
       <hashes>
         <hash alg="SHA-256">e9f4614a380b0a44c3dc99c9c6f689e128fe4d86e5c3be7b6ea62065a3aae596</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/yalp/jsonpath@v0.0.0-20180802001716-5cc68e5049a0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -2498,6 +3691,13 @@
       <hashes>
         <hash alg="SHA-256">dbb71b7ea5cb544275a3c23abf7cbd960f18766e7710aa875c038cc441a508e0</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/yudai/gojsondiff@v1.0.0</purl>
       <externalReferences>
         <reference type="vcs">
@@ -2512,6 +3712,13 @@
       <hashes>
         <hash alg="SHA-256">047c9f2a5432a9bb05379a7721f9c451db96bdbf62b38dbcfe735be4bdd4d353</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/yudai/golcs@v0.0.0-20170316035057-ecda9a501e82</purl>
       <externalReferences>
         <reference type="vcs">
@@ -2540,6 +3747,13 @@
       <hashes>
         <hash alg="SHA-256">5c0cf1f608c26f44718fb128a9c0a53c3d5de590716499348dbba83c77a706dd</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/go.etcd.io/bbolt@v1.3.5</purl>
     </component>
     <component bom-ref="pkg:golang/github.com/ProtonMail/crypto@v0.0.0-20201112115411-41db4ea0dd1c" type="library">
@@ -2549,6 +3763,13 @@
       <hashes>
         <hash alg="SHA-256">89a55b10e9ec9121a0707ed74161c6e953e2ac70d1a187be21d774fdd9789bc0</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/github.com/ProtonMail/crypto@v0.0.0-20201112115411-41db4ea0dd1c</purl>
       <externalReferences>
         <reference type="vcs">
@@ -2563,6 +3784,13 @@
       <hashes>
         <hash alg="SHA-256">7acb64d6094e9d255e27db5d11965ce6600c0d993994d24dc89e83beb0644c45</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/golang.org/x/exp@v0.0.0-20190731235908-ec7cb31e5a56</purl>
     </component>
     <component bom-ref="pkg:golang/golang.org/x/image@v0.0.0-20190802002840-cff245a6509b" type="library">
@@ -2572,6 +3800,13 @@
       <hashes>
         <hash alg="SHA-256">faa1291003e10d9d68d31ded1f365340302b9ce8b13b3183f475097dc83499be</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/golang.org/x/image@v0.0.0-20190802002840-cff245a6509b</purl>
     </component>
     <component bom-ref="pkg:golang/golang.org/x/mobile@v0.0.0-20200801112145-973feb4309de" type="library">
@@ -2581,6 +3816,13 @@
       <hashes>
         <hash alg="SHA-256">39527a41050101eb01f026628ca0d2b175fbc5856d521ae463483031f6e2e29e</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/golang.org/x/mobile@v0.0.0-20200801112145-973feb4309de</purl>
     </component>
     <component bom-ref="pkg:golang/golang.org/x/mod@v0.1.1-0.20191209134235-331c550502dd" type="library">
@@ -2590,43 +3832,78 @@
       <hashes>
         <hash alg="SHA-256">78fb8d0bb3d9e8ee41ce03e7f5b65ac8445705d7d98d46285c47f90537c37e1f</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/golang.org/x/mod@v0.1.1-0.20191209134235-331c550502dd</purl>
     </component>
-    <component bom-ref="pkg:golang/golang.org/x/net@v0.0.0-20200707034311-ab3426394381" type="library">
+    <component bom-ref="pkg:golang/golang.org/x/net@v0.0.0-20210405180319-a5a99cb37ef4" type="library">
       <name>golang.org/x/net</name>
-      <version>v0.0.0-20200707034311-ab3426394381</version>
+      <version>v0.0.0-20210405180319-a5a99cb37ef4</version>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">5576a4e48e9a1169805de42303e41267396036ba6af668dc7c37a6b9ec482ac5</hash>
+        <hash alg="SHA-256">e2719a56ed10adb8d3fc02b63d12ee41f42e87a0c9bdefa910b86a4dd023df1d</hash>
       </hashes>
-      <purl>pkg:golang/golang.org/x/net@v0.0.0-20200707034311-ab3426394381</purl>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/golang.org/x/net@v0.0.0-20210405180319-a5a99cb37ef4</purl>
     </component>
-    <component bom-ref="pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e" type="library">
+    <component bom-ref="pkg:golang/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c" type="library">
       <name>golang.org/x/sync</name>
-      <version>v0.0.0-20190911185100-cd5d95a43a6e</version>
+      <version>v0.0.0-20210220032951-036812b2e83c</version>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">bdcc466a84ecee457c9b9369f6e50d4229f806b2ceb61815ef6e7637c57e1706</hash>
+        <hash alg="SHA-256">e4ab25198c05a6484687e435e9bc0c3f770ea27b47f0539ea7bb4657ce98ed24</hash>
       </hashes>
-      <purl>pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e</purl>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c</purl>
     </component>
-    <component bom-ref="pkg:golang/golang.org/x/sys@v0.0.0-20200323222414-85ca7c5b95cd" type="library">
+    <component bom-ref="pkg:golang/golang.org/x/sys@v0.0.0-20210330210617-4fbd30eecc44" type="library">
       <name>golang.org/x/sys</name>
-      <version>v0.0.0-20200323222414-85ca7c5b95cd</version>
+      <version>v0.0.0-20210330210617-4fbd30eecc44</version>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">c619b0caf8b3b93802daacfb665325b8fdb4b96f82dd19b4143fd62c35fcf3ce</hash>
+        <hash alg="SHA-256">0658b8d69225cd3cdfdca118d3a9fec67ccafc1112220db37b83e07e1fda23c7</hash>
       </hashes>
-      <purl>pkg:golang/golang.org/x/sys@v0.0.0-20200323222414-85ca7c5b95cd</purl>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/golang.org/x/sys@v0.0.0-20210330210617-4fbd30eecc44</purl>
     </component>
-    <component bom-ref="pkg:golang/golang.org/x/term@v0.0.0-20201117132131-f5c789dd3221" type="library">
+    <component bom-ref="pkg:golang/golang.org/x/term@v0.0.0-20201126162022-7de9c90e9dd1" type="library">
       <name>golang.org/x/term</name>
-      <version>v0.0.0-20201117132131-f5c789dd3221</version>
+      <version>v0.0.0-20201126162022-7de9c90e9dd1</version>
       <scope>required</scope>
       <hashes>
-        <hash alg="SHA-256">fd91dd6d5a5d47f8e4de0df4fdde3250bd0953d924b23f3e17f6e741454b1833</hash>
+        <hash alg="SHA-256">bfe3acb16417fa14c7126381830c5d6712b8cc7ab7c8eb3c17d27b9a4d0f63c1</hash>
       </hashes>
-      <purl>pkg:golang/golang.org/x/term@v0.0.0-20201117132131-f5c789dd3221</purl>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
+      <purl>pkg:golang/golang.org/x/term@v0.0.0-20201126162022-7de9c90e9dd1</purl>
     </component>
     <component bom-ref="pkg:golang/golang.org/x/text@v0.3.5-0.20201125200606-c27b9fd57aec" type="library">
       <name>golang.org/x/text</name>
@@ -2635,6 +3912,13 @@
       <hashes>
         <hash alg="SHA-256">035a988e7789bb305967680807caddeb3adfaba97b4a810c27c12c4a294d2bf5</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/golang.org/x/text@v0.3.5-0.20201125200606-c27b9fd57aec</purl>
     </component>
     <component bom-ref="pkg:golang/golang.org/x/tools@v0.0.0-20200117012304-6edc0a871e69" type="library">
@@ -2644,6 +3928,13 @@
       <hashes>
         <hash alg="SHA-256">c811c7c7e5d9a972419ba13191edcded5f609e5b325f1a023c46f5c957a78df9</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/golang.org/x/tools@v0.0.0-20200117012304-6edc0a871e69</purl>
     </component>
     <component bom-ref="pkg:golang/golang.org/x/xerrors@v0.0.0-20191204190536-9bdfabe68543" type="library">
@@ -2653,6 +3944,13 @@
       <hashes>
         <hash alg="SHA-256">13b83ef46213ab4ee1a5fad1bbae885437b131a91fbf9d9e2d9d825c15a22abe</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/golang.org/x/xerrors@v0.0.0-20191204190536-9bdfabe68543</purl>
     </component>
     <component bom-ref="pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f" type="library">
@@ -2662,6 +3960,13 @@
       <hashes>
         <hash alg="SHA-256">04bada1579e6adebf9953fb196296a707f172bdfe2d00b76c4a8d6938a7acec5</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>BSD-2-Clause</id>
+          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f</purl>
       <externalReferences>
         <reference type="vcs">
@@ -2676,6 +3981,13 @@
       <hashes>
         <hash alg="SHA-256">c4e1cb5d9c15bc8f6186cf9c2caab9f88e689cebb040b850c22bbadf1c651ece</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/gopkg.in/fsnotify.v1@v1.4.7</purl>
       <externalReferences>
         <reference type="vcs">
@@ -2690,6 +4002,13 @@
       <hashes>
         <hash alg="SHA-256">c6862e25513b293f393d85ab37bdf4460b8840ed1e3f35517c531769d22b5d33</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/gopkg.in/go-playground/assert.v1@v1.2.1</purl>
       <externalReferences>
         <reference type="vcs">
@@ -2704,6 +4023,13 @@
       <hashes>
         <hash alg="SHA-256">9450780e8314e81eb6eb0f27cbbe8c57b557e96d951dcb76195388df182232b4</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/gopkg.in/go-playground/validator.v8@v8.18.2</purl>
       <externalReferences>
         <reference type="vcs">
@@ -2718,6 +4044,13 @@
       <hashes>
         <hash alg="SHA-256">1b26e81ebe14a8c88b5326d88dddb6663408284244a60b4b5edb866d1db53a1a</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <name>Apache License 2.0</name>
+          <url>https://spdx.org/licenses/Apache-2.0.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/gopkg.in/ini.v1@v1.51.1</purl>
       <externalReferences>
         <reference type="vcs">
@@ -2732,6 +4065,13 @@
       <hashes>
         <hash alg="SHA-256">c5c1168d586f6c3cbe9c73faee73c30e96d8ad8f882e57e7764e1b462a151da5</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>BSD-2-Clause</id>
+          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/gopkg.in/mgo.v2@v2.0.0-20180705113604-9856a29383ce</purl>
       <externalReferences>
         <reference type="vcs">
@@ -2746,6 +4086,13 @@
       <hashes>
         <hash alg="SHA-256">b9118975c88e1da108af37b65bc43700a91ea4b4e1da13aba13edafbb7337dd4</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
+          <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7</purl>
       <externalReferences>
         <reference type="vcs">
@@ -2760,6 +4107,13 @@
       <hashes>
         <hash alg="SHA-256">a1b37565a809494188d0493f2c19ae8f848d2cf7c89f2dcab0a168a7145d8f5d</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <name>Apache License 2.0</name>
+          <url>https://spdx.org/licenses/Apache-2.0.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/gopkg.in/yaml.v2@v2.2.8</purl>
       <externalReferences>
         <reference type="vcs">
@@ -2774,28 +4128,22 @@
       <hashes>
         <hash alg="SHA-256">7545301e4d90102a3feafa80e38aed859f227b641730d78a4531c2358da75efa</hash>
       </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <name>Apache License 2.0</name>
+          <url>https://spdx.org/licenses/Apache-2.0.html</url>
+        </license>
+        <license>
+          <id>MIT</id>
+          <name>MIT License</name>
+          <url>https://spdx.org/licenses/MIT.html</url>
+        </license>
+      </licenses>
       <purl>pkg:golang/gopkg.in/yaml.v3@v3.0.0-20200313102051-9f266ea9e77c</purl>
       <externalReferences>
         <reference type="vcs">
           <url>https://github.com/go-yaml/yaml</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component bom-ref="pkg:golang/std@1.16.2" type="library">
-      <name>std</name>
-      <version>1.16.2</version>
-      <description>The Go standard library</description>
-      <scope>required</scope>
-      <purl>pkg:golang/std@1.16.2</purl>
-      <externalReferences>
-        <reference type="documentation">
-          <url>https://golang.org/pkg/</url>
-        </reference>
-        <reference type="vcs">
-          <url>https://go.googlesource.com/go</url>
-        </reference>
-        <reference type="website">
-          <url>https://golang.org/</url>
         </reference>
       </externalReferences>
     </component>
@@ -2812,9 +4160,7 @@
     <dependency ref="pkg:golang/github.com/Joker/hpp@v1.0.0"></dependency>
     <dependency ref="pkg:golang/github.com/Masterminds/semver/v3@v3.1.0"></dependency>
     <dependency ref="pkg:golang/github.com/ProtonMail/go-autostart@v0.0.0-20181114175602-c5272053443a"></dependency>
-    <dependency ref="pkg:golang/github.com/ProtonMail/go-crypto@v0.0.0-20201208171014-cdb7591792e2">
-      <dependency ref="pkg:golang/golang.org/x/term@v0.0.0-20201117132131-f5c789dd3221"></dependency>
-    </dependency>
+    <dependency ref="pkg:golang/github.com/ProtonMail/go-crypto@v0.0.0-20201208171014-cdb7591792e2"></dependency>
     <dependency ref="pkg:golang/github.com/ProtonMail/go-imap-id@v0.0.0-20190926060100-f94a56b9ecde"></dependency>
     <dependency ref="pkg:golang/github.com/ProtonMail/go-mime@v0.0.0-20190923161245-9b5a4261663a"></dependency>
     <dependency ref="pkg:golang/github.com/ProtonMail/go-rfc5322@v0.5.0">
@@ -2876,7 +4222,7 @@
     <dependency ref="pkg:golang/github.com/emersion/go-imap-appendlimit@v0.0.0-20190308131241-25671c986a6a"></dependency>
     <dependency ref="pkg:golang/github.com/emersion/go-imap-idle@v0.0.0-20200601154248-f05f54664cc4"></dependency>
     <dependency ref="pkg:golang/github.com/emersion/go-imap-move@v0.0.0-20190710073258-6e5a51a5b342"></dependency>
-    <dependency ref="pkg:golang/github.com/emersion/go-imap-quota@v0.0.0-20200423100218-dcfd1b7d2b41"></dependency>
+    <dependency ref="pkg:golang/github.com/emersion/go-imap-quota@v0.0.0-20210203125329-619074823f3c"></dependency>
     <dependency ref="pkg:golang/github.com/emersion/go-imap-unselect@v0.0.0-20171113212723-b985794e5f26"></dependency>
     <dependency ref="pkg:golang/github.com/emersion/go-mbox@v1.0.2"></dependency>
     <dependency ref="pkg:golang/github.com/emersion/go-message@v0.12.1-0.20201221184100-40c3f864532b">
@@ -2941,7 +4287,9 @@
     <dependency ref="pkg:golang/github.com/go-check/check@v0.0.0-20180628173108-788fd7840127"></dependency>
     <dependency ref="pkg:golang/github.com/go-errors/errors@v1.0.1"></dependency>
     <dependency ref="pkg:golang/github.com/go-martini/martini@v0.0.0-20170121215854-22fa46961aab"></dependency>
-    <dependency ref="pkg:golang/github.com/go-resty/resty/v2@v2.3.0"></dependency>
+    <dependency ref="pkg:golang/github.com/go-resty/resty/v2@v2.6.0">
+      <dependency ref="pkg:golang/golang.org/x/net@v0.0.0-20210405180319-a5a99cb37ef4"></dependency>
+    </dependency>
     <dependency ref="pkg:golang/github.com/gobwas/httphead@v0.0.0-20180130184737-2c6c146eadee"></dependency>
     <dependency ref="pkg:golang/github.com/gobwas/pool@v0.2.0"></dependency>
     <dependency ref="pkg:golang/github.com/gobwas/ws@v1.0.2"></dependency>
@@ -3027,7 +4375,6 @@
       <dependency ref="pkg:golang/github.com/iris-contrib/go.uuid@v2.0.0"></dependency>
       <dependency ref="pkg:golang/github.com/mediocregopher/radix/v3@v3.4.2"></dependency>
       <dependency ref="pkg:golang/github.com/nats-io/nats.go@v1.9.1"></dependency>
-      <dependency ref="pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e"></dependency>
     </dependency>
     <dependency ref="pkg:golang/github.com/kataras/pio@v0.0.2"></dependency>
     <dependency ref="pkg:golang/github.com/kataras/sitemap@v0.0.5"></dependency>
@@ -3069,7 +4416,9 @@
       <dependency ref="pkg:golang/github.com/pmezard/go-difflib@v1.0.0"></dependency>
     </dependency>
     <dependency ref="pkg:golang/github.com/microcosm-cc/bluemonday@v1.0.2"></dependency>
-    <dependency ref="pkg:golang/github.com/miekg/dns@v1.1.30"></dependency>
+    <dependency ref="pkg:golang/github.com/miekg/dns@v1.1.41">
+      <dependency ref="pkg:golang/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c"></dependency>
+    </dependency>
     <dependency ref="pkg:golang/github.com/mitchellh/go-homedir@v1.1.0"></dependency>
     <dependency ref="pkg:golang/github.com/mitchellh/mapstructure@v1.1.2"></dependency>
     <dependency ref="pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd"></dependency>
@@ -3208,13 +4557,13 @@
       <dependency ref="pkg:golang/golang.org/x/tools@v0.0.0-20200117012304-6edc0a871e69"></dependency>
     </dependency>
     <dependency ref="pkg:golang/golang.org/x/mod@v0.1.1-0.20191209134235-331c550502dd"></dependency>
-    <dependency ref="pkg:golang/golang.org/x/net@v0.0.0-20200707034311-ab3426394381">
-      <dependency ref="pkg:golang/github.com/ProtonMail/crypto@v0.0.0-20201112115411-41db4ea0dd1c"></dependency>
-      <dependency ref="pkg:golang/golang.org/x/sys@v0.0.0-20200323222414-85ca7c5b95cd"></dependency>
+    <dependency ref="pkg:golang/golang.org/x/net@v0.0.0-20210405180319-a5a99cb37ef4">
+      <dependency ref="pkg:golang/golang.org/x/sys@v0.0.0-20210330210617-4fbd30eecc44"></dependency>
+      <dependency ref="pkg:golang/golang.org/x/term@v0.0.0-20201126162022-7de9c90e9dd1"></dependency>
     </dependency>
-    <dependency ref="pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e"></dependency>
-    <dependency ref="pkg:golang/golang.org/x/sys@v0.0.0-20200323222414-85ca7c5b95cd"></dependency>
-    <dependency ref="pkg:golang/golang.org/x/term@v0.0.0-20201117132131-f5c789dd3221"></dependency>
+    <dependency ref="pkg:golang/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c"></dependency>
+    <dependency ref="pkg:golang/golang.org/x/sys@v0.0.0-20210330210617-4fbd30eecc44"></dependency>
+    <dependency ref="pkg:golang/golang.org/x/term@v0.0.0-20201126162022-7de9c90e9dd1"></dependency>
     <dependency ref="pkg:golang/golang.org/x/text@v0.3.5-0.20201125200606-c27b9fd57aec"></dependency>
     <dependency ref="pkg:golang/golang.org/x/tools@v0.0.0-20200117012304-6edc0a871e69"></dependency>
     <dependency ref="pkg:golang/golang.org/x/xerrors@v0.0.0-20191204190536-9bdfabe68543"></dependency>
@@ -3227,7 +4576,7 @@
     <dependency ref="pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7"></dependency>
     <dependency ref="pkg:golang/gopkg.in/yaml.v2@v2.2.8"></dependency>
     <dependency ref="pkg:golang/gopkg.in/yaml.v3@v3.0.0-20200313102051-9f266ea9e77c"></dependency>
-    <dependency ref="pkg:golang/github.com/ProtonMail/proton-bridge@v1.6.3">
+    <dependency ref="pkg:golang/github.com/ProtonMail/proton-bridge@v1.8.0">
       <dependency ref="pkg:golang/github.com/0xAX/notificator@v0.0.0-20191016112426-3962a5ea8da1"></dependency>
       <dependency ref="pkg:golang/github.com/Masterminds/semver/v3@v3.1.0"></dependency>
       <dependency ref="pkg:golang/github.com/ProtonMail/go-autostart@v0.0.0-20181114175602-c5272053443a"></dependency>
@@ -3247,7 +4596,7 @@
       <dependency ref="pkg:golang/github.com/emersion/go-imap-appendlimit@v0.0.0-20190308131241-25671c986a6a"></dependency>
       <dependency ref="pkg:golang/github.com/emersion/go-imap-idle@v0.0.0-20200601154248-f05f54664cc4"></dependency>
       <dependency ref="pkg:golang/github.com/emersion/go-imap-move@v0.0.0-20190710073258-6e5a51a5b342"></dependency>
-      <dependency ref="pkg:golang/github.com/emersion/go-imap-quota@v0.0.0-20200423100218-dcfd1b7d2b41"></dependency>
+      <dependency ref="pkg:golang/github.com/emersion/go-imap-quota@v0.0.0-20210203125329-619074823f3c"></dependency>
       <dependency ref="pkg:golang/github.com/emersion/go-imap-unselect@v0.0.0-20171113212723-b985794e5f26"></dependency>
       <dependency ref="pkg:golang/github.com/emersion/go-mbox@v1.0.2"></dependency>
       <dependency ref="pkg:golang/github.com/emersion/go-message@v0.12.1-0.20201221184100-40c3f864532b"></dependency>
@@ -3258,7 +4607,7 @@
       <dependency ref="pkg:golang/github.com/fatih/color@v1.9.0"></dependency>
       <dependency ref="pkg:golang/github.com/flynn-archive/go-shlex@v0.0.0-20150515145356-3f9db97f8568"></dependency>
       <dependency ref="pkg:golang/github.com/getsentry/sentry-go@v0.8.0"></dependency>
-      <dependency ref="pkg:golang/github.com/go-resty/resty/v2@v2.3.0"></dependency>
+      <dependency ref="pkg:golang/github.com/go-resty/resty/v2@v2.6.0"></dependency>
       <dependency ref="pkg:golang/github.com/golang/mock@v1.4.4"></dependency>
       <dependency ref="pkg:golang/github.com/google/go-cmp@v0.5.1"></dependency>
       <dependency ref="pkg:golang/github.com/google/uuid@v1.1.1"></dependency>
@@ -3269,7 +4618,7 @@
       <dependency ref="pkg:golang/github.com/keybase/go-keychain@v0.0.0-20200502122510-cda31fe0c86d"></dependency>
       <dependency ref="pkg:golang/github.com/logrusorgru/aurora@v2.0.3"></dependency>
       <dependency ref="pkg:golang/github.com/mattn/go-runewidth@v0.0.9"></dependency>
-      <dependency ref="pkg:golang/github.com/miekg/dns@v1.1.30"></dependency>
+      <dependency ref="pkg:golang/github.com/miekg/dns@v1.1.41"></dependency>
       <dependency ref="pkg:golang/github.com/nsf/jsondiff@v0.0.0-20200515183724-f29ed568f4ce"></dependency>
       <dependency ref="pkg:golang/github.com/olekukonko/tablewriter@v0.0.4"></dependency>
       <dependency ref="pkg:golang/github.com/pkg/errors@v0.9.1"></dependency>
@@ -3282,10 +4631,8 @@
       <dependency ref="pkg:golang/github.com/vmihailenco/msgpack/v5@v5.1.3"></dependency>
       <dependency ref="pkg:golang/go.etcd.io/bbolt@v1.3.5"></dependency>
       <dependency ref="pkg:golang/github.com/ProtonMail/crypto@v0.0.0-20201112115411-41db4ea0dd1c"></dependency>
-      <dependency ref="pkg:golang/golang.org/x/net@v0.0.0-20200707034311-ab3426394381"></dependency>
+      <dependency ref="pkg:golang/golang.org/x/net@v0.0.0-20210405180319-a5a99cb37ef4"></dependency>
       <dependency ref="pkg:golang/golang.org/x/text@v0.3.5-0.20201125200606-c27b9fd57aec"></dependency>
-      <dependency ref="pkg:golang/std@1.16.2"></dependency>
     </dependency>
-    <dependency ref="pkg:golang/std@1.16.2"></dependency>
   </dependencies>
 </bom>

--- a/proton-bridge/proton-bridge-v1.8.0.bom.xml
+++ b/proton-bridge/proton-bridge-v1.8.0.bom.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.2" serialNumber="urn:uuid:c609c10a-0764-4c10-9ff4-6e544322a2a6" version="1">
+<bom xmlns="http://cyclonedx.org/schema/bom/1.2" serialNumber="urn:uuid:74e6d3e0-8df7-4717-a567-3c9046fa719c" version="1">
   <metadata>
-    <timestamp>2021-05-16T15:41:15+02:00</timestamp>
+    <timestamp>2021-05-16T17:10:00+02:00</timestamp>
     <tools>
       <tool>
         <vendor>CycloneDX</vendor>
         <name>cyclonedx-gomod</name>
-        <version>v0.6.0</version>
+        <version>v0.6.1</version>
         <hashes>
-          <hash alg="MD5">d0517cb759962ccf9c41c8a12875a8f4</hash>
-          <hash alg="SHA-1">0a7059c2ba93d66a6f3b895ea446a74ab8cf24d0</hash>
-          <hash alg="SHA-256">d9695be77c111ebff786b384581b76ccbf4e8e4463969f6e6e22e9dd9a7ed465</hash>
-          <hash alg="SHA-512">9e6f27516614980c9a745574dcf755679efaacf5cf2beafaf1a5ad67ff99f568f811bbac65e9641f3f82c9da8066d28e5487f52f6b1fa179ec9a878e8a7d461d</hash>
+          <hash alg="MD5">a92d9f6145a94c2c7ad8489d84301eb9</hash>
+          <hash alg="SHA-1">a5af6c5ef3f21bf5425c680b64acf57cc6a90c69</hash>
+          <hash alg="SHA-256">dc215a651772356eca763d6fe77169379c1cc25c2bb89c7d6df2e2170c3972ab</hash>
+          <hash alg="SHA-512">387953ab509c31bf352693de9df617650c87494e607119bc284b91ba9a0a2d284a2e96946c272dc284c4370875412eea855bc30351faedd099dbdbed209e4636</hash>
         </hashes>
       </tool>
     </tools>
@@ -37,7 +37,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -58,12 +57,10 @@
       <licenses>
         <license>
           <id>CC0-1.0</id>
-          <name>Creative Commons Zero v1.0 Universal</name>
           <url>https://spdx.org/licenses/CC0-1.0.html</url>
         </license>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -84,7 +81,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -105,8 +101,10 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+        <license>
+          <name>GooglePatentClause</name>
         </license>
       </licenses>
       <purl>pkg:golang/github.com/BurntSushi/xgb@v0.0.0-20160522181843-27f122750802</purl>
@@ -126,7 +124,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -147,7 +144,6 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
-          <name>Apache License 2.0</name>
           <url>https://spdx.org/licenses/Apache-2.0.html</url>
         </license>
       </licenses>
@@ -168,7 +164,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -189,7 +184,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -210,7 +204,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -231,7 +224,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -252,7 +244,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -273,7 +264,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -294,7 +284,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -315,7 +304,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -336,7 +324,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -357,7 +344,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -378,7 +364,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -399,7 +384,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -420,7 +404,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -441,7 +424,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -462,7 +444,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -483,7 +464,6 @@
       <licenses>
         <license>
           <id>BSD-2-Clause</id>
-          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
           <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
         </license>
       </licenses>
@@ -504,12 +484,10 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -530,7 +508,6 @@
       <licenses>
         <license>
           <id>MPL-2.0</id>
-          <name>Mozilla Public License 2.0</name>
           <url>https://spdx.org/licenses/MPL-2.0.html</url>
         </license>
       </licenses>
@@ -551,7 +528,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -586,7 +562,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -607,7 +582,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -628,7 +602,6 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
-          <name>Apache License 2.0</name>
           <url>https://spdx.org/licenses/Apache-2.0.html</url>
         </license>
       </licenses>
@@ -649,7 +622,6 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
-          <name>Apache License 2.0</name>
           <url>https://spdx.org/licenses/Apache-2.0.html</url>
         </license>
       </licenses>
@@ -670,7 +642,6 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
-          <name>Apache License 2.0</name>
           <url>https://spdx.org/licenses/Apache-2.0.html</url>
         </license>
       </licenses>
@@ -691,7 +662,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -712,7 +682,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -733,7 +702,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -754,7 +722,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -775,7 +742,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -796,7 +762,6 @@
       <licenses>
         <license>
           <id>ISC</id>
-          <name>ISC License</name>
           <url>https://spdx.org/licenses/ISC.html</url>
         </license>
       </licenses>
@@ -817,7 +782,6 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
-          <name>Apache License 2.0</name>
           <url>https://spdx.org/licenses/Apache-2.0.html</url>
         </license>
       </licenses>
@@ -852,7 +816,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -887,7 +850,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -908,7 +870,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -943,7 +904,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -964,7 +924,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -985,7 +944,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -1006,7 +964,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -1027,7 +984,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -1048,7 +1004,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -1069,7 +1024,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -1090,7 +1044,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -1111,7 +1064,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -1132,7 +1084,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -1153,7 +1104,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -1174,7 +1124,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -1209,7 +1158,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -1230,7 +1178,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -1251,7 +1198,6 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
-          <name>Apache License 2.0</name>
           <url>https://spdx.org/licenses/Apache-2.0.html</url>
         </license>
       </licenses>
@@ -1272,7 +1218,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -1293,7 +1238,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -1314,7 +1258,6 @@
       <licenses>
         <license>
           <id>BSD-2-Clause</id>
-          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
           <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
         </license>
       </licenses>
@@ -1335,7 +1278,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -1356,7 +1298,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -1377,7 +1318,6 @@
       <licenses>
         <license>
           <id>BSD-2-Clause</id>
-          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
           <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
         </license>
       </licenses>
@@ -1398,7 +1338,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -1419,7 +1358,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -1440,7 +1378,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -1461,7 +1398,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -1482,7 +1418,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -1503,7 +1438,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -1524,7 +1458,6 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
-          <name>Apache License 2.0</name>
           <url>https://spdx.org/licenses/Apache-2.0.html</url>
         </license>
       </licenses>
@@ -1545,7 +1478,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -1566,7 +1498,6 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
-          <name>Apache License 2.0</name>
           <url>https://spdx.org/licenses/Apache-2.0.html</url>
         </license>
       </licenses>
@@ -1587,7 +1518,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -1608,7 +1538,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -1629,7 +1558,6 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
-          <name>Apache License 2.0</name>
           <url>https://spdx.org/licenses/Apache-2.0.html</url>
         </license>
       </licenses>
@@ -1650,7 +1578,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -1671,7 +1598,6 @@
       <licenses>
         <license>
           <id>BSD-2-Clause</id>
-          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
           <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
         </license>
       </licenses>
@@ -1692,7 +1618,6 @@
       <licenses>
         <license>
           <id>BSD-2-Clause</id>
-          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
           <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
         </license>
       </licenses>
@@ -1713,7 +1638,6 @@
       <licenses>
         <license>
           <id>MPL-2.0</id>
-          <name>Mozilla Public License 2.0</name>
           <url>https://spdx.org/licenses/MPL-2.0.html</url>
         </license>
       </licenses>
@@ -1734,7 +1658,6 @@
       <licenses>
         <license>
           <id>MPL-2.0</id>
-          <name>Mozilla Public License 2.0</name>
           <url>https://spdx.org/licenses/MPL-2.0.html</url>
         </license>
       </licenses>
@@ -1755,7 +1678,6 @@
       <licenses>
         <license>
           <id>MPL-2.0</id>
-          <name>Mozilla Public License 2.0</name>
           <url>https://spdx.org/licenses/MPL-2.0.html</url>
         </license>
       </licenses>
@@ -1776,7 +1698,6 @@
       <licenses>
         <license>
           <id>MPL-2.0</id>
-          <name>Mozilla Public License 2.0</name>
           <url>https://spdx.org/licenses/MPL-2.0.html</url>
         </license>
       </licenses>
@@ -1797,7 +1718,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -1818,7 +1738,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -1839,7 +1758,6 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
-          <name>Apache License 2.0</name>
           <url>https://spdx.org/licenses/Apache-2.0.html</url>
         </license>
       </licenses>
@@ -1860,7 +1778,6 @@
       <licenses>
         <license>
           <id>BSD-2-Clause</id>
-          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
           <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
         </license>
       </licenses>
@@ -1881,7 +1798,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -1902,7 +1818,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -1923,7 +1838,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -1958,7 +1872,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -1979,7 +1892,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2000,7 +1912,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2021,7 +1932,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2042,7 +1952,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2063,7 +1972,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -2084,7 +1992,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -2105,7 +2012,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2126,7 +2032,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -2147,7 +2052,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2168,7 +2072,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2189,7 +2092,6 @@
       <licenses>
         <license>
           <id>BSD-2-Clause</id>
-          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
           <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
         </license>
       </licenses>
@@ -2210,7 +2112,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -2231,7 +2132,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2252,7 +2152,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2273,7 +2172,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2294,7 +2192,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2315,7 +2212,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2336,7 +2232,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2357,7 +2252,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2378,7 +2272,6 @@
       <licenses>
         <license>
           <id>Unlicense</id>
-          <name>The Unlicense</name>
           <url>https://spdx.org/licenses/Unlicense.html</url>
         </license>
       </licenses>
@@ -2399,7 +2292,6 @@
       <licenses>
         <license>
           <id>BSD-2-Clause</id>
-          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
           <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
         </license>
       </licenses>
@@ -2420,7 +2312,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2441,7 +2332,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2462,7 +2352,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2483,7 +2372,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2518,7 +2406,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2539,7 +2426,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -2560,7 +2446,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -2581,7 +2466,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2602,7 +2486,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2623,7 +2506,6 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
-          <name>Apache License 2.0</name>
           <url>https://spdx.org/licenses/Apache-2.0.html</url>
         </license>
       </licenses>
@@ -2644,7 +2526,6 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
-          <name>Apache License 2.0</name>
           <url>https://spdx.org/licenses/Apache-2.0.html</url>
         </license>
       </licenses>
@@ -2665,7 +2546,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2686,7 +2566,6 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
-          <name>Apache License 2.0</name>
           <url>https://spdx.org/licenses/Apache-2.0.html</url>
         </license>
       </licenses>
@@ -2707,7 +2586,6 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
-          <name>Apache License 2.0</name>
           <url>https://spdx.org/licenses/Apache-2.0.html</url>
         </license>
       </licenses>
@@ -2728,7 +2606,6 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
-          <name>Apache License 2.0</name>
           <url>https://spdx.org/licenses/Apache-2.0.html</url>
         </license>
       </licenses>
@@ -2749,7 +2626,6 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
-          <name>Apache License 2.0</name>
           <url>https://spdx.org/licenses/Apache-2.0.html</url>
         </license>
       </licenses>
@@ -2770,7 +2646,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2791,7 +2666,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2812,7 +2686,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2833,7 +2706,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2854,7 +2726,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2875,7 +2746,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -2896,7 +2766,6 @@
       <licenses>
         <license>
           <id>BSD-2-Clause</id>
-          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
           <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
         </license>
       </licenses>
@@ -2917,7 +2786,6 @@
       <licenses>
         <license>
           <id>BSD-2-Clause</id>
-          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
           <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
         </license>
       </licenses>
@@ -2938,7 +2806,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -2959,7 +2826,6 @@
       <licenses>
         <license>
           <id>BSD-2-Clause</id>
-          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
           <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
         </license>
       </licenses>
@@ -2980,7 +2846,6 @@
       <licenses>
         <license>
           <id>BSD-2-Clause</id>
-          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
           <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
         </license>
       </licenses>
@@ -3001,7 +2866,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -3022,7 +2886,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -3043,7 +2906,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -3064,7 +2926,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -3085,7 +2946,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -3106,7 +2966,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -3127,7 +2986,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -3148,7 +3006,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -3169,7 +3026,6 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
-          <name>Apache License 2.0</name>
           <url>https://spdx.org/licenses/Apache-2.0.html</url>
         </license>
       </licenses>
@@ -3190,7 +3046,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -3211,7 +3066,6 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
-          <name>Apache License 2.0</name>
           <url>https://spdx.org/licenses/Apache-2.0.html</url>
         </license>
       </licenses>
@@ -3232,7 +3086,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -3253,7 +3106,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -3274,7 +3126,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -3295,7 +3146,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -3316,7 +3166,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -3337,7 +3186,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -3358,7 +3206,6 @@
       <licenses>
         <license>
           <id>LGPL-3.0</id>
-          <name>GNU Lesser General Public License v3.0 only</name>
           <url>https://spdx.org/licenses/LGPL-3.0.html</url>
         </license>
       </licenses>
@@ -3379,7 +3226,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -3400,7 +3246,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -3421,7 +3266,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -3442,7 +3286,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -3463,7 +3306,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -3484,7 +3326,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -3505,7 +3346,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -3526,7 +3366,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -3547,7 +3386,6 @@
       <licenses>
         <license>
           <id>BSD-2-Clause</id>
-          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
           <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
         </license>
       </licenses>
@@ -3568,7 +3406,6 @@
       <licenses>
         <license>
           <id>BSD-2-Clause</id>
-          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
           <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
         </license>
       </licenses>
@@ -3589,7 +3426,6 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
-          <name>Apache License 2.0</name>
           <url>https://spdx.org/licenses/Apache-2.0.html</url>
         </license>
       </licenses>
@@ -3610,7 +3446,6 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
-          <name>Apache License 2.0</name>
           <url>https://spdx.org/licenses/Apache-2.0.html</url>
         </license>
       </licenses>
@@ -3631,7 +3466,6 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
-          <name>Apache License 2.0</name>
           <url>https://spdx.org/licenses/Apache-2.0.html</url>
         </license>
       </licenses>
@@ -3652,7 +3486,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -3673,7 +3506,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -3694,7 +3526,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -3715,7 +3546,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -3750,7 +3580,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -3766,7 +3595,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -3787,7 +3615,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -3803,7 +3630,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -3819,7 +3645,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -3835,7 +3660,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -3851,7 +3675,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -3867,7 +3690,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -3883,7 +3705,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -3899,7 +3720,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -3915,7 +3735,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -3931,7 +3750,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -3947,7 +3765,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -3963,7 +3780,6 @@
       <licenses>
         <license>
           <id>BSD-2-Clause</id>
-          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
           <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
         </license>
       </licenses>
@@ -3984,7 +3800,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -4005,7 +3820,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -4026,7 +3840,6 @@
       <licenses>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>
@@ -4047,7 +3860,6 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
-          <name>Apache License 2.0</name>
           <url>https://spdx.org/licenses/Apache-2.0.html</url>
         </license>
       </licenses>
@@ -4068,7 +3880,6 @@
       <licenses>
         <license>
           <id>BSD-2-Clause</id>
-          <name>BSD 2-Clause &#34;Simplified&#34; License</name>
           <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
         </license>
       </licenses>
@@ -4089,7 +3900,6 @@
       <licenses>
         <license>
           <id>BSD-3-Clause</id>
-          <name>BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License</name>
           <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
         </license>
       </licenses>
@@ -4110,7 +3920,6 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
-          <name>Apache License 2.0</name>
           <url>https://spdx.org/licenses/Apache-2.0.html</url>
         </license>
       </licenses>
@@ -4131,12 +3940,10 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
-          <name>Apache License 2.0</name>
           <url>https://spdx.org/licenses/Apache-2.0.html</url>
         </license>
         <license>
           <id>MIT</id>
-          <name>MIT License</name>
           <url>https://spdx.org/licenses/MIT.html</url>
         </license>
       </licenses>


### PR DESCRIPTION
As of *cyclonedx-gomod* v0.6.0, generated SBOMs include license information. I also added SBOMs for another version of *proton-bridge* to address #5.